### PR TITLE
drop unused dependencies

### DIFF
--- a/pilz_extensions/CHANGELOG.rst
+++ b/pilz_extensions/CHANGELOG.rst
@@ -2,6 +2,9 @@
 Changelog for package pilz_extensions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+Forthcoming
+-----------
+
 0.1.0 (2018-09-14)
 ------------------
 * extension to joint_limits_interface::JointLimits

--- a/pilz_industrial_motion/CHANGELOG.rst
+++ b/pilz_industrial_motion/CHANGELOG.rst
@@ -2,6 +2,9 @@
 Changelog for package pilz_industrial_motion
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+Forthcoming
+-----------
+
 0.1.0 (2018-09-14)
 ------------------
 * Initial release

--- a/pilz_industrial_motion_testutils/CHANGELOG.rst
+++ b/pilz_industrial_motion_testutils/CHANGELOG.rst
@@ -2,6 +2,9 @@
 Changelog for package pilz_industrial_motion_testutils
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+Forthcoming
+-----------
+
 0.1.0 (2018-09-14)
 ------------------
 * xml test data loader.

--- a/pilz_msgs/CHANGELOG.rst
+++ b/pilz_msgs/CHANGELOG.rst
@@ -2,6 +2,9 @@
 Changelog for package pilz_msgs
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+Forthcoming
+-----------
+
 0.1.0 (2018-09-14)
 ------------------
 * Added msg definition for blend request and response

--- a/pilz_trajectory_generation/CHANGELOG.rst
+++ b/pilz_trajectory_generation/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package pilz_trajectory_generation
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+Forthcoming
+-----------
+* drop unused dependencies
+* Contributors: Pilz GmbH and Co. KG
+
 0.1.0 (2018-09-14)
 ------------------
 * Created trajectory generation package with ptp, lin, circ and blend planner

--- a/pilz_trajectory_generation/CMakeLists.txt
+++ b/pilz_trajectory_generation/CMakeLists.txt
@@ -19,12 +19,9 @@ find_package(catkin REQUIRED COMPONENTS
   tf2
   tf2_eigen
   tf2_geometry_msgs
-  tf_conversions
   moveit_ros_move_group
   moveit_ros_planning_interface
-  rospy
   pilz_industrial_motion_testutils
-  roslint
 )
 
 

--- a/pilz_trajectory_generation/package.xml
+++ b/pilz_trajectory_generation/package.xml
@@ -19,7 +19,6 @@
   <build_depend>moveit_core</build_depend>
   <build_depend>moveit_ros_planning</build_depend> <!-- RobotModelLoader -->
   <build_depend>moveit_ros_move_group</build_depend> <!-- move_group capability -->
-  <build_depend>tf_conversions</build_depend>
   <build_depend>tf2</build_depend>
   <build_depend>tf2_geometry_msgs</build_depend>
   <build_depend>tf2_eigen</build_depend>
@@ -27,8 +26,6 @@
   <build_depend>pilz_extensions</build_depend>
   <build_depend>pilz_msgs</build_depend>
   <build_depend>moveit_ros_planning_interface</build_depend>
-  <build_depend>rospy</build_depend>
-  <build_depend>roslint</build_depend>
 
   <run_depend>orocos_kdl</run_depend>
   <run_depend>roscpp</run_depend>
@@ -42,12 +39,10 @@
   <run_depend>pilz_extensions</run_depend>
 
   <run_depend>pilz_msgs</run_depend>
-  <run_depend>tf_conversions</run_depend>
   <run_depend>tf2</run_depend>
   <run_depend>tf2_geometry_msgs</run_depend>
   <run_depend>message_runtime</run_depend>
   <run_depend>moveit_ros_planning_interface</run_depend>
-  <run_depend>rospy</run_depend>
 
   <!-- Test dependencies -->
   <test_depend>rostest</test_depend>

--- a/pilz_trajectory_generation/src/trajectory_generator_circ.cpp
+++ b/pilz_trajectory_generation/src/trajectory_generator_circ.cpp
@@ -21,8 +21,6 @@
 #include <ros/ros.h>
 #include <eigen_conversions/eigen_msg.h>
 #include <moveit/robot_state/conversions.h>
-#include <tf/transform_datatypes.h>
-#include <tf_conversions/tf_eigen.h>
 #include <eigen_conversions/eigen_kdl.h>
 #include <kdl_conversions/kdl_msg.h>
 #include <kdl/utilities/error.h>

--- a/pilz_trajectory_generation/src/trajectory_generator_lin.cpp
+++ b/pilz_trajectory_generation/src/trajectory_generator_lin.cpp
@@ -19,8 +19,6 @@
 #include "ros/ros.h"
 #include "eigen_conversions/eigen_msg.h"
 #include "moveit/robot_state/conversions.h"
-#include <tf/transform_datatypes.h>
-#include <tf_conversions/tf_eigen.h>
 #include <eigen_conversions/eigen_kdl.h>
 #include <kdl/path_line.hpp>
 #include <kdl/utilities/error.h>

--- a/pilz_trajectory_generation/test/test_utils.cpp
+++ b/pilz_trajectory_generation/test/test_utils.cpp
@@ -18,8 +18,6 @@
 #include <gtest/gtest.h>
 
 #include "test_utils.h"
-#include <tf_conversions/tf_eigen.h>
-#include <tf/transform_datatypes.h>
 #include <eigen_conversions/eigen_msg.h>
 #include <moveit/robot_state/conversions.h>
 #include <moveit/planning_interface/planning_interface.h>


### PR DESCRIPTION
Drop the packages we currently do not use from package.xml and headers files in pilz_trajectory_generation.