### PR TITLE
fix missing dependency in testutils

### DIFF
--- a/pilz_industrial_motion_testutils/CMakeLists.txt
+++ b/pilz_industrial_motion_testutils/CMakeLists.txt
@@ -12,6 +12,7 @@ find_package(catkin REQUIRED COMPONENTS
   moveit_core
   moveit_msgs
   pilz_msgs
+  eigen_conversions
 )
 
 find_package(Boost REQUIRED COMPONENTS)

--- a/pilz_industrial_motion_testutils/package.xml
+++ b/pilz_industrial_motion_testutils/package.xml
@@ -15,6 +15,7 @@
   <build_depend>moveit_core</build_depend>
   <build_depend>moveit_msgs</build_depend>
   <build_depend>pilz_msgs</build_depend>
+  <build_depend>eigen_conversions</build_depend>
 
   <run_depend>moveit_core</run_depend>
   <run_depend>moveit_msgs</run_depend>


### PR DESCRIPTION
To fix isolated package build on buildfarm:
http://build.ros.org/view/Mbin_uB64/job/Mbin_uB64__pilz_industrial_motion_testutils__ubuntu_bionic_amd64__binary/15/console