### PR TITLE
Rename Blend->Sequence in pilz_industrial_motion_testutils

### DIFF
--- a/pilz_industrial_motion_testutils/include/pilz_industrial_motion_testutils/testdata_loader.h
+++ b/pilz_industrial_motion_testutils/include/pilz_industrial_motion_testutils/testdata_loader.h
@@ -37,7 +37,7 @@ enum class ECircAuxPosType
   eCENTER
 };
 
-struct SBlendCmd
+struct SSequenceCmd
 {
   std::string cmd_name;
   std::string cmd_type;
@@ -110,8 +110,8 @@ public:
    * @brief Returns a container containing the cmds which make-up the
    * blend cmd. The cmds in the container are in the order of execution.
    */
-  virtual bool getBlend(const std::string &cmd_name,
-                        std::vector<SBlendCmd> &blend_cmds) const = 0;
+  virtual bool getSequence(const std::string &cmd_name,
+                           std::vector<SSequenceCmd> &seq_cmds) const = 0;
 
 public:
    static geometry_msgs::Pose fromVecToMsg(const std::vector<double>& vec);

--- a/pilz_industrial_motion_testutils/include/pilz_industrial_motion_testutils/xml_testdata_loader.h
+++ b/pilz_industrial_motion_testutils/include/pilz_industrial_motion_testutils/xml_testdata_loader.h
@@ -93,13 +93,13 @@ namespace pilz_industrial_motion_testutils
  *    </circ>
  *  </circs>
  *
- *  <blends>
+ *  <sequences>
  *    <blend name="TestBlend">
- *      <blendCmd name="TestPtp" type="ptp" blend_radius="0.2" />
- *      <blendCmd name="MyTestLin1" type="lin" blend_radius="0.01" />
- *      <blendCmd name="MyTestCirc1" type="circ" blend_radius="0" />
+ *      <sequenceCmd name="TestPtp" type="ptp" blend_radius="0.2" />
+ *      <sequenceCmd name="MyTestLin1" type="lin" blend_radius="0.01" />
+ *      <sequenceCmd name="MyTestCirc1" type="circ" blend_radius="0" />
  *    </blend>
- *  <blends>
+ *  </sequences>
  *
  * </testdata>
  */
@@ -121,8 +121,8 @@ public:
 
   virtual bool getCirc(const std::string& cmd_name, STestMotionCommand& cmd) const override;
 
-  virtual bool getBlend(const std::string &cmd_name,
-                        std::vector<SBlendCmd> &blend_cmds) const override;
+  virtual bool getSequence(const std::string &cmd_name,
+                           std::vector<SSequenceCmd> &seq_cmds) const override;
 
 private:
   /**
@@ -189,7 +189,7 @@ private:
   const std::string PTPS_PATH_STR {"testdata.ptps"};
   const std::string LINS_PATH_STR {"testdata.lins"};
   const std::string CIRCS_PATH_STR {"testdata.circs"};
-  const std::string BLENDS_PATH_STR {"testdata.blends"};
+  const std::string SEQUENCE_PATH_STR {"testdata.sequences"};
 
   const std::string NAME_PATH_STR {XML_ATTR_STR + ".name"};
   const std::string CMD_TYPE_PATH_STR {XML_ATTR_STR + ".type"};

--- a/pilz_industrial_motion_testutils/src/pilz_industrial_motion_testutils/xml_testdata_loader.py
+++ b/pilz_industrial_motion_testutils/src/pilz_industrial_motion_testutils/xml_testdata_loader.py
@@ -43,7 +43,7 @@ _PATH_TO_POSE = "./poses/pos[@name='{pose_name}']/group[@name='{group_name}']/xy
 _PATH_TO_PTP = "./ptps/ptp[@name='{name_of_cmd}']"
 _PATH_TO_LIN = "./lins/lin[@name='{name_of_cmd}']"
 _PATH_TO_CIRC = "./circs/circ[@name='{name_of_cmd}']"
-_PATH_TO_BLEND = "./blends/blend[@name='{name_of_cmd}']"
+_PATH_TO_SEQUENCE = "./sequences/sequence[@name='{name_of_cmd}']"
 
 
 class XmlTestdataLoader:
@@ -108,29 +108,29 @@ class XmlTestdataLoader:
                 PLANNING_GROUP_STR: cmdRes[PLANNING_GROUP_STR], LINK_NAME_STR: cmdRes[LINK_NAME_STR]}
 
     # Returns a list of dictionaries containing the cmds which make-up the
-    # blend cmd. The cmds in the list are in the order of execution.
+    # sequence cmd. The cmds in the list are in the order of execution.
     # In case of an error 'None' is returned.
-    def get_blend(self, name_of_cmd):
-        # Find the blend command with the given name
-        blendNode = self._root.find(_PATH_TO_BLEND.format(name_of_cmd=name_of_cmd))
-        if blendNode is None:
+    def get_sequence(self, name_of_cmd):
+        # Find the sequence command with the given name
+        sequenceNode = self._root.find(_PATH_TO_SEQUENCE.format(name_of_cmd=name_of_cmd))
+        if sequenceNode is None:
             return None
 
         # Loop over all blend commands
-        blendCmds = []
-        for blendCmdNode in blendNode.getchildren():
-            cmd_name = blendCmdNode.get(NAME_STR)
+        sequenceCmds = []
+        for sequenceCmdNode in sequenceNode.getchildren():
+            cmd_name = sequenceCmdNode.get(NAME_STR)
             if cmd_name is None:
                 return None
 
-            cmd_type = blendCmdNode.get(TYPE_STR)
+            cmd_type = sequenceCmdNode.get(TYPE_STR)
             if cmd_type is None:
                 return None
 
-            blend_radius = blendCmdNode.get(BLEND_RADIUS_STR, DEFAULT_BLEND_RADIUS)
-            blendCmds.append({NAME_STR: cmd_name, TYPE_STR: cmd_type, BLEND_RADIUS_STR: blend_radius})
+            blend_radius = sequenceCmdNode.get(BLEND_RADIUS_STR, DEFAULT_BLEND_RADIUS)
+            sequenceCmds.append({NAME_STR: cmd_name, TYPE_STR: cmd_type, BLEND_RADIUS_STR: blend_radius})
 
-        return blendCmds
+        return sequenceCmds
 
     # Returns the start- and end-position, as well as
     # the velocity and acceleration of the given command type, given by its name.

--- a/pilz_industrial_motion_testutils/src/xml_testdata_loader.cpp
+++ b/pilz_industrial_motion_testutils/src/xml_testdata_loader.cpp
@@ -311,45 +311,45 @@ bool XmlTestdataLoader::getCirc(const std::string &cmd_name, STestMotionCommand 
   return true;
 }
 
-bool XmlTestdataLoader::getBlend(const std::string &cmd_name,
-                                 std::vector<SBlendCmd> &blend_cmds) const
+bool XmlTestdataLoader::getSequence(const std::string &cmd_name,
+                                    std::vector<SSequenceCmd> &seq_cmds) const
 {
-  // Find blend cmd with given name
+  // Find sequence cmd with given name
   bool ok {false};
-  const pt::ptree::value_type &blend_node { findCmd(cmd_name, BLENDS_PATH_STR, ok) };
+  const pt::ptree::value_type &sequence_node { findCmd(cmd_name, SEQUENCE_PATH_STR, ok) };
   if (!ok){ return false; }
 
-  // Loop over all blend cmds.
-  const auto& blend_cmd_tree = blend_node.second;
-  for (const pt::ptree::value_type& blend_cmd : blend_cmd_tree)
+  // Loop over all sequence cmds.
+  const auto& sequence_cmd_tree = sequence_node.second;
+  for (const pt::ptree::value_type& seq_cmd : sequence_cmd_tree)
   {
     // Ignore attributes which are always the first element of a tree.
-    if (blend_cmd.first == XML_ATTR_STR){ continue; }
+    if (seq_cmd.first == XML_ATTR_STR){ continue; }
 
     // Get name of blend cmd.
-    const boost::property_tree::ptree& cmd_name_attr = blend_cmd.second.get_child(NAME_PATH_STR, empty_tree_);
+    const boost::property_tree::ptree& cmd_name_attr = seq_cmd.second.get_child(NAME_PATH_STR, empty_tree_);
     if (cmd_name_attr == empty_tree_)
     {
-      ROS_ERROR("Did not find name of blend cmd.");
+      ROS_ERROR("Did not find name of sequence cmd.");
       return false;
     }
-    SBlendCmd blend_cmd_data;
-    blend_cmd_data.cmd_name = cmd_name_attr.data();
+    SSequenceCmd sequence_cmd_data;
+    sequence_cmd_data.cmd_name = cmd_name_attr.data();
 
     // Get type of blend cmd.
-    const boost::property_tree::ptree& type_name_attr = blend_cmd.second.get_child(CMD_TYPE_PATH_STR, empty_tree_);
+    const boost::property_tree::ptree& type_name_attr = seq_cmd.second.get_child(CMD_TYPE_PATH_STR, empty_tree_);
     if (type_name_attr == empty_tree_)
     {
-      ROS_ERROR_STREAM("Did not find type of blend cmd '" << blend_cmd_data.cmd_name << "'." );
+      ROS_ERROR_STREAM("Did not find type of sequence cmd '" << sequence_cmd_data.cmd_name << "'." );
       return false;
     }
-    blend_cmd_data.cmd_type = type_name_attr.data();
+    sequence_cmd_data.cmd_type = type_name_attr.data();
 
     // Get blend radius of blend cmd.
-    blend_cmd_data.blend_radius = blend_cmd.second.get<double>(BLEND_RADIUS_PATH_STR, DEFAULT_BLEND_RADIUS);
+    sequence_cmd_data.blend_radius = seq_cmd.second.get<double>(BLEND_RADIUS_PATH_STR, DEFAULT_BLEND_RADIUS);
 
     // Add blend cmd to container.
-    blend_cmds.push_back(blend_cmd_data);
+    seq_cmds.push_back(sequence_cmd_data);
   }
   return true;
 }

--- a/pilz_industrial_motion_testutils/test_data/testdata.xml
+++ b/pilz_industrial_motion_testutils/test_data/testdata.xml
@@ -260,17 +260,17 @@ limitations under the License.
         </circ>
     </circs>
 
-    <blends>
-        <blend name="LINLINBlend">
-            <blendCmd name="Blend_1_1_Lin" type="lin" blend_radius="0.1"/>
-            <blendCmd name="Blend_1_2_Lin" type="lin" blend_radius="0" />
-        </blend>
+    <sequences>
+        <sequence name="LINLINBlend">
+            <sequenceCmd name="Blend_1_1_Lin" type="lin" blend_radius="0.1"/>
+            <sequenceCmd name="Blend_1_2_Lin" type="lin" blend_radius="0" />
+        </sequence>
 
-        <blend name="InvalidLINLINBlend">
-            <blendCmd name="Blend_1_1_Lin_invalid" type="lin" blend_radius="0.12"/>
-            <blendCmd name="Blend_1_2_Lin" type="lin" blend_radius="0.1" />
-            <blendCmd name="Blend_1_3_Lin" type="lin" blend_radius="0" />
-        </blend>
-    </blends>
+        <sequence name="InvalidLINLINBlend">
+            <sequenceCmd name="Blend_1_1_Lin_invalid" type="lin" blend_radius="0.12"/>
+            <sequenceCmd name="Blend_1_2_Lin" type="lin" blend_radius="0.1" />
+            <sequenceCmd name="Blend_1_3_Lin" type="lin" blend_radius="0" />
+        </sequence>
+    </sequences>
 
 </testdata>


### PR DESCRIPTION
Further renaming from blend -> sequence
in pilz_industrial_motion_testutils
E.g. `<blend> -> <sequence>, SBlendCmd SSequenceCmd`