### PR TITLE
Add new function signature for isRobotStateEqual

### DIFF
--- a/pilz_trajectory_generation/include/pilz_trajectory_generation/trajectory_functions.h
+++ b/pilz_trajectory_generation/include/pilz_trajectory_generation/trajectory_functions.h
@@ -164,17 +164,29 @@ bool determineAndCheckSamplingTime(const robot_trajectory::RobotTrajectoryPtr& f
                                    double& sampling_time);
 
 /**
- * @brief check if the two robot states have the same joint position/velocity/acceleration
- * @param state1:
- * @param state2
- * @param group
- * @param EPSILON
- * @return
+ * @brief Deprecated, do not use this function signature anymore.
+ *
+ * @deprecated use the other function signature taking const references to the robot states.
+ *
  */
 bool isRobotStateEqual(const robot_state::RobotStatePtr& state1,
                        const robot_state::RobotStatePtr& state2,
-                       const std::string& group,
-                       double EPSILON);
+                       const std::string& joint_group_name,
+                       double epsilon);
+
+/**
+ * @brief Check if the two robot states have the same joint position/velocity/acceleration.
+ *
+ * @param joint_group_name The name of the joint group.
+ * @param epsilon Constants defining how close the joint position/velocity/acceleration have to be to be
+ * recognized as equal.
+ *
+ * @return True if joint positions, joint velocities and joint accelerations are equal, otherwise false.
+ */
+bool isRobotStateEqual(const robot_state::RobotState& state1,
+                       const robot_state::RobotState& state2,
+                       const std::string& joint_group_name,
+                       double epsilon);
 
 /**
  * @brief check if the robot state have zero velocity/acceleartion

--- a/pilz_trajectory_generation/src/trajectory_functions.cpp
+++ b/pilz_trajectory_generation/src/trajectory_functions.cpp
@@ -486,15 +486,24 @@ bool pilz::determineAndCheckSamplingTime(const robot_trajectory::RobotTrajectory
 
 bool pilz::isRobotStateEqual(const moveit::core::RobotStatePtr &state1,
                              const moveit::core::RobotStatePtr &state2,
-                             const std::string &group,
-                             double EPSILON)
+                             const std::string &joint_group_name,
+                             double epsilon)
+{
+  ROS_WARN("This signature of isRobotStateEqual is deprecated. Please use the new one in the future.");
+  return isRobotStateEqual(*state1, *state2, joint_group_name, epsilon);
+}
+
+bool pilz::isRobotStateEqual(const moveit::core::RobotState &state1,
+                             const moveit::core::RobotState &state2,
+                             const std::string &joint_group_name,
+                             double epsilon)
 {
   Eigen::VectorXd joint_position_1, joint_position_2;
 
-  state1->copyJointGroupPositions(group, joint_position_1);
-  state2->copyJointGroupPositions(group, joint_position_2);
+  state1.copyJointGroupPositions(joint_group_name, joint_position_1);
+  state2.copyJointGroupPositions(joint_group_name, joint_position_2);
 
-  if( (joint_position_1 - joint_position_2).norm() > EPSILON)
+  if( (joint_position_1 - joint_position_2).norm() > epsilon)
   {
     ROS_ERROR_STREAM("Joint positions of the two states are different. state1: " << joint_position_1 << " state2: "
                      << joint_position_2);
@@ -503,10 +512,10 @@ bool pilz::isRobotStateEqual(const moveit::core::RobotStatePtr &state1,
 
   Eigen::VectorXd joint_velocity_1, joint_velocity_2;
 
-  state1->copyJointGroupVelocities(group, joint_velocity_1);
-  state2->copyJointGroupVelocities(group, joint_velocity_2);
+  state1.copyJointGroupVelocities(joint_group_name, joint_velocity_1);
+  state2.copyJointGroupVelocities(joint_group_name, joint_velocity_2);
 
-  if( (joint_velocity_1 - joint_velocity_2).norm() > EPSILON)
+  if( (joint_velocity_1 - joint_velocity_2).norm() > epsilon)
   {
     ROS_ERROR_STREAM("Joint velocities of the two states are different. state1: " << joint_velocity_1 << " state2: "
                      << joint_velocity_2);
@@ -515,10 +524,10 @@ bool pilz::isRobotStateEqual(const moveit::core::RobotStatePtr &state1,
 
   Eigen::VectorXd joint_acc_1, joint_acc_2;
 
-  state1->copyJointGroupAccelerations(group, joint_acc_1);
-  state2->copyJointGroupAccelerations(group, joint_acc_2);
+  state1.copyJointGroupAccelerations(joint_group_name, joint_acc_1);
+  state2.copyJointGroupAccelerations(joint_group_name, joint_acc_2);
 
-  if( (joint_acc_1 - joint_acc_2).norm() > EPSILON)
+  if( (joint_acc_1 - joint_acc_2).norm() > epsilon)
   {
     ROS_ERROR_STREAM("Joint accelerations of the two states are different. state1: " << joint_acc_1 << " state2: "
                      << joint_acc_2);


### PR DESCRIPTION
Since we do not want to manipulate the robot states, the new function
only takes const references. The former signature is kept but marked deprecated.