### PR TITLE
Refactor/robot motion observer

### DIFF
--- a/pilz_industrial_motion_testutils/src/pilz_industrial_motion_testutils/integration_test_utils.py
+++ b/pilz_industrial_motion_testutils/src/pilz_industrial_motion_testutils/integration_test_utils.py
@@ -17,7 +17,6 @@
 # limitations under the License.
 
 import rospy
-import numpy
 import threading
 from pilz_robot_programming.robot import RobotMoveFailed
 
@@ -26,58 +25,6 @@ def waited_trigger(cv, func):
     with cv:
         cv.wait()
     func()
-
-
-def detect_motion(joint_values_a, joint_values_b, tolerance):
-    """TRUE if a significant motion was detected, otherwise FALSE."""
-    return not numpy.allclose(joint_values_a, joint_values_b,
-                              atol=tolerance)
-
-
-def is_robot_moving(robot, time=0.1, tolerance=0.01):
-    start_position = robot.get_current_joint_states()
-    rospy.sleep(time)
-    return detect_motion(start_position, robot.get_current_joint_states(), tolerance)
-
-
-def wait_cmd_start(robot, sleep_time, move_tolerance, group_name="manipulator"):
-    """Wait till movement starts. """
-    movement_started_flag = False
-    old_joint_values = robot.get_current_joint_states(group_name)
-    rospy.loginfo("Start joint values: " + str(old_joint_values))
-    rospy.loginfo("Wait until motion started...")
-    while not movement_started_flag:
-        rospy.sleep(sleep_time)
-        # Check current joint values
-        curr_joint_values = robot.get_current_joint_states(group_name)
-        if detect_motion(curr_joint_values, old_joint_values, move_tolerance):
-            movement_started_flag = True
-            rospy.loginfo("Changed joint values detected: " + str(curr_joint_values))
-            rospy.loginfo("Motion started.")
-
-
-def wait_cmd_stop(robot, wait_time_out, move_tolerance, sleep_interval=0.01):
-    """Wait till movement stops. """
-    old_joint_values = robot.get_current_joint_states()
-
-    rospy.loginfo("Start joint values: " + str(old_joint_values))
-    rospy.loginfo("Wait until motion stops...")
-
-    wait_time = 0
-
-    while wait_time < wait_time_out:
-        rospy.sleep(sleep_interval)
-        wait_time += sleep_interval
-        curr_joint_values = robot.get_current_joint_states()
-        if not detect_motion(curr_joint_values, old_joint_values, move_tolerance):
-            rospy.loginfo("Motion stopped.")
-            return True
-        else:
-            old_joint_values = curr_joint_values
-            rospy.loginfo("Changed joint values detected: " + str(curr_joint_values))
-
-    rospy.loginfo("Motion did not stop in " + str(wait_time) + " seconds")
-    return False
 
 
 class MoveThread(threading.Thread):

--- a/pilz_industrial_motion_testutils/src/pilz_industrial_motion_testutils/robot_motion_observer.py
+++ b/pilz_industrial_motion_testutils/src/pilz_industrial_motion_testutils/robot_motion_observer.py
@@ -29,9 +29,9 @@ class RobotMotionObserver(object):
     :param group_name: Name of the planning group, default value is 'manipulator'
     """
 
-    _DEFAULT_WAIT_TIME_FOR_MOTION_DETECTION = 3.0
-    _DEFAULT_TOLERANCE_FOR_MOTION_DETECTION = 0.01
-    _DEFAULT_SLEEP_INTERVAL = 0.01
+    _DEFAULT_WAIT_TIME_FOR_MOTION_DETECTION_SEC = 3.0
+    _DEFAULT_TOLERANCE_FOR_MOTION_DETECTION_RAD = 0.01
+    _DEFAULT_SLEEP_INTERVAL_SEC = 0.01
     _DEFAULT_GROUP_NAME = "manipulator"
 
     def __init__(self, group_name=_DEFAULT_GROUP_NAME):
@@ -39,7 +39,7 @@ class RobotMotionObserver(object):
         self._group_name = group_name
 
     @staticmethod
-    def _detect_motion(joint_values_a, joint_values_b, tolerance=_DEFAULT_TOLERANCE_FOR_MOTION_DETECTION):
+    def _detect_motion(joint_values_a, joint_values_b, tolerance=_DEFAULT_TOLERANCE_FOR_MOTION_DETECTION_RAD):
         """TRUE if a significant motion was detected, otherwise FALSE."""
         return not numpy.allclose(joint_values_a, joint_values_b,
                                   atol=tolerance)
@@ -55,17 +55,17 @@ class RobotMotionObserver(object):
             raise RobotCurrentStateError(e.message)
 
     def is_robot_moving(self,
-                        sleep_interval=_DEFAULT_SLEEP_INTERVAL,
-                        move_tolerance=_DEFAULT_TOLERANCE_FOR_MOTION_DETECTION):
+                        sleep_interval=_DEFAULT_SLEEP_INTERVAL_SEC,
+                        move_tolerance=_DEFAULT_TOLERANCE_FOR_MOTION_DETECTION_RAD):
         """TRUE if the robot is currently moving, otherwise FLASE."""
         start_position = self._get_current_joint_states()
         rospy.sleep(sleep_interval)
         return RobotMotionObserver._detect_motion(start_position, self._get_current_joint_states(), move_tolerance)
 
     def wait_motion_start(self,
-                          wait_time_out=_DEFAULT_WAIT_TIME_FOR_MOTION_DETECTION,
-                          move_tolerance=_DEFAULT_TOLERANCE_FOR_MOTION_DETECTION,
-                          sleep_interval=_DEFAULT_SLEEP_INTERVAL):
+                          wait_time_out=_DEFAULT_WAIT_TIME_FOR_MOTION_DETECTION_SEC,
+                          move_tolerance=_DEFAULT_TOLERANCE_FOR_MOTION_DETECTION_RAD,
+                          sleep_interval=_DEFAULT_SLEEP_INTERVAL_SEC):
         """TRUE if the motion started in the given time interval, otherwise FALSE."""
 
         old_joint_values = self._get_current_joint_states()
@@ -92,9 +92,9 @@ class RobotMotionObserver(object):
         return motion_started
 
     def wait_motion_stop(self,
-                         wait_time_out=_DEFAULT_WAIT_TIME_FOR_MOTION_DETECTION,
-                         move_tolerance=_DEFAULT_TOLERANCE_FOR_MOTION_DETECTION,
-                         sleep_interval=_DEFAULT_SLEEP_INTERVAL):
+                         wait_time_out=_DEFAULT_WAIT_TIME_FOR_MOTION_DETECTION_SEC,
+                         move_tolerance=_DEFAULT_TOLERANCE_FOR_MOTION_DETECTION_RAD,
+                         sleep_interval=_DEFAULT_SLEEP_INTERVAL_SEC):
         """TRUE if the motion stopped in the given time interval, otherwise FALSE."""
 
         motion_stopped = False

--- a/pilz_industrial_motion_testutils/src/pilz_industrial_motion_testutils/robot_motion_observer.py
+++ b/pilz_industrial_motion_testutils/src/pilz_industrial_motion_testutils/robot_motion_observer.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+#
+# Copyright © 2018 Pilz GmbH & Co. KG
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import rospy
+import numpy
+from moveit_commander import RobotCommander, MoveItCommanderException
+
+
+class RobotMotionObserver(object):
+    """Observes motions of the robot.
+
+    The implementation is based on using the get_current_joint_values()) functionality of the RobotCommander().
+
+    :param group_name: Name of the planning group, default value is 'manipulator'
+    """
+
+    _DEFAULT_WAIT_TIME_FOR_MOTION_DETECTION = 3.0
+    _DEFAULT_TOLERANCE_FOR_MOTION_DETECTION = 0.01
+    _DEFAULT_SLEEP_INTERVAL = 0.01
+    _DEFAULT_GROUP_NAME = "manipulator"
+
+    def __init__(self, group_name=_DEFAULT_GROUP_NAME):
+        self._robot_commander = RobotCommander()
+        self._group_name = group_name
+
+    @staticmethod
+    def _detect_motion(joint_values_a, joint_values_b, tolerance=_DEFAULT_TOLERANCE_FOR_MOTION_DETECTION):
+        """TRUE if a significant motion was detected, otherwise FALSE."""
+        return not numpy.allclose(joint_values_a, joint_values_b,
+                                  atol=tolerance)
+
+    def _get_current_joint_states(self):
+        """Returns the current joint state values of the robot.
+        :raises RobotCurrentStateError if given planning group does not exist.
+        """
+        try:
+            return self._robot_commander.get_group(self._group_name).get_current_joint_values()
+        except MoveItCommanderException as e:
+            rospy.logerr(e.message)
+            raise RobotCurrentStateError(e.message)
+
+    def is_robot_moving(self,
+                        sleep_interval=_DEFAULT_SLEEP_INTERVAL,
+                        move_tolerance=_DEFAULT_TOLERANCE_FOR_MOTION_DETECTION):
+        """TRUE if the robot is currently moving, otherwise FLASE."""
+        start_position = self._get_current_joint_states()
+        rospy.sleep(sleep_interval)
+        return RobotMotionObserver._detect_motion(start_position, self._get_current_joint_states(), move_tolerance)
+
+    def wait_motion_start(self,
+                          wait_time_out=_DEFAULT_WAIT_TIME_FOR_MOTION_DETECTION,
+                          sleep_interval=_DEFAULT_SLEEP_INTERVAL,
+                          move_tolerance=_DEFAULT_TOLERANCE_FOR_MOTION_DETECTION):
+        """TRUE if the motion started in the given time interval, otherwise FALSE."""
+
+        old_joint_values = self._get_current_joint_states()
+        rospy.loginfo("Start joint values: " + str(old_joint_values))
+
+        motion_started = False
+        start_time = rospy.get_time()
+        rospy.loginfo("Wait until motion starts...")
+
+        while True:
+            rospy.sleep(sleep_interval)
+            curr_joint_values = self._get_current_joint_states()
+
+            if RobotMotionObserver._detect_motion(curr_joint_values, old_joint_values, move_tolerance):
+                motion_started = True
+                rospy.loginfo("Changed joint values detected: " + str(curr_joint_values))
+                rospy.loginfo("Motion started.")
+                break
+
+            if (rospy.get_time() - start_time > wait_time_out):
+                rospy.loginfo("Reached timeout when waiting for motion start.")
+                break
+
+        return motion_started
+
+    def wait_motion_stop(self,
+                         wait_time_out=_DEFAULT_WAIT_TIME_FOR_MOTION_DETECTION,
+                         sleep_interval=_DEFAULT_SLEEP_INTERVAL,
+                         move_tolerance=_DEFAULT_TOLERANCE_FOR_MOTION_DETECTION):
+        """TRUE if the motion stopped in the given time interval, otherwise FALSE."""
+
+        motion_stopped = False
+        start_time = rospy.get_time()
+        rospy.loginfo("Wait until motion stops...")
+
+        while True:
+
+            if not self.is_robot_moving(sleep_interval, move_tolerance):
+                motion_stopped = True
+                rospy.loginfo("Motion stopped.")
+                break
+
+            if (rospy.get_time() - start_time > wait_time_out):
+                rospy.loginfo("Reached timeout when waiting for motion stop.")
+                break
+
+        return motion_stopped

--- a/pilz_industrial_motion_testutils/src/pilz_industrial_motion_testutils/robot_motion_observer.py
+++ b/pilz_industrial_motion_testutils/src/pilz_industrial_motion_testutils/robot_motion_observer.py
@@ -64,8 +64,8 @@ class RobotMotionObserver(object):
 
     def wait_motion_start(self,
                           wait_time_out=_DEFAULT_WAIT_TIME_FOR_MOTION_DETECTION,
-                          sleep_interval=_DEFAULT_SLEEP_INTERVAL,
-                          move_tolerance=_DEFAULT_TOLERANCE_FOR_MOTION_DETECTION):
+                          move_tolerance=_DEFAULT_TOLERANCE_FOR_MOTION_DETECTION,
+                          sleep_interval=_DEFAULT_SLEEP_INTERVAL):
         """TRUE if the motion started in the given time interval, otherwise FALSE."""
 
         old_joint_values = self._get_current_joint_states()
@@ -93,8 +93,8 @@ class RobotMotionObserver(object):
 
     def wait_motion_stop(self,
                          wait_time_out=_DEFAULT_WAIT_TIME_FOR_MOTION_DETECTION,
-                         sleep_interval=_DEFAULT_SLEEP_INTERVAL,
-                         move_tolerance=_DEFAULT_TOLERANCE_FOR_MOTION_DETECTION):
+                         move_tolerance=_DEFAULT_TOLERANCE_FOR_MOTION_DETECTION,
+                         sleep_interval=_DEFAULT_SLEEP_INTERVAL):
         """TRUE if the motion stopped in the given time interval, otherwise FALSE."""
 
         motion_stopped = False

--- a/pilz_robot_programming/test/acceptance_tests/acceptance_test_move_ctrl.py
+++ b/pilz_robot_programming/test/acceptance_tests/acceptance_test_move_ctrl.py
@@ -18,11 +18,13 @@ from pilz_robot_programming.robot import *
 from pilz_robot_programming.commands import *
 from pilz_industrial_motion_testutils.acceptance_test_utils import _askPermission, _askSuccess
 from pilz_industrial_motion_testutils.integration_test_utils import *
+from pilz_industrial_motion_testutils.robot_motion_observer import RobotMotionObserver
 
 _SLEEP_TIME_S = 0.01
 _TOLERANCE_FOR_MOTION_DETECTION_RAD = 0.3
 _DEFAULT_VEL_SCALE = 0.1
 _REQUIRED_API_VERSION = "1"
+_PLANNING_GROUP = "manipulator"
 
 
 def start_program():
@@ -52,11 +54,14 @@ def _test_stop(robot):
     if _askPermission(_test_stop.__name__) == 0:
         return
 
+    _robot_motion_observer = RobotMotionObserver(_PLANNING_GROUP)
+
     # 1. Create simple ptp command and start thread for movement
     ptp = Ptp(goal=[0, -0.78, 0.78, 0, 1.56, 0], vel_scale=_DEFAULT_VEL_SCALE)
     move_thread = MoveThread(robot, ptp)
     move_thread.start()
-    wait_cmd_start(robot, _SLEEP_TIME_S, _TOLERANCE_FOR_MOTION_DETECTION_RAD)
+    _robot_motion_observer.wait_motion_start(sleep_interval=_SLEEP_TIME_S,
+                                             move_tolerance=_TOLERANCE_FOR_MOTION_DETECTION_RAD)
 
     # 2. Trigger stop
     robot.stop()
@@ -88,11 +93,14 @@ def _test_pause_resume(robot):
     if _askPermission(_test_pause_resume.__name__) == 0:
         return
 
+    _robot_motion_observer = RobotMotionObserver(_PLANNING_GROUP)
+
     # 1. Create simple ptp command and start thread for movement
     ptp = Ptp(goal=[0, 0.39, -0.39, 0, 0.78, 0], vel_scale=_DEFAULT_VEL_SCALE)
     move_thread = MoveThread(robot, ptp)
     move_thread.start()
-    wait_cmd_start(robot, _SLEEP_TIME_S, _TOLERANCE_FOR_MOTION_DETECTION_RAD)
+    _robot_motion_observer.wait_motion_start(sleep_interval=_SLEEP_TIME_S,
+                                             move_tolerance=_TOLERANCE_FOR_MOTION_DETECTION_RAD)
 
     # 2. Trigger pause
     robot.pause()
@@ -124,11 +132,14 @@ def _test_pause_stop(robot):
     if _askPermission(_test_pause_stop.__name__) == 0:
         return
 
+    _robot_motion_observer = RobotMotionObserver(_PLANNING_GROUP)
+
     # 1. Create simple ptp command and start thread for movement
     ptp = Ptp(goal=[0, -0.78, 0.78, 0, 1.56, 0], vel_scale=_DEFAULT_VEL_SCALE)
     move_thread = MoveThread(robot, ptp)
     move_thread.start()
-    wait_cmd_start(robot, _SLEEP_TIME_S, _TOLERANCE_FOR_MOTION_DETECTION_RAD)
+    _robot_motion_observer.wait_motion_start(sleep_interval=_SLEEP_TIME_S,
+                                             move_tolerance=_TOLERANCE_FOR_MOTION_DETECTION_RAD)
 
     # 2. Trigger pause
     robot.pause()

--- a/pilz_robot_programming/test/integrationtests/tst_api_execution_stop.py
+++ b/pilz_robot_programming/test/integrationtests/tst_api_execution_stop.py
@@ -19,6 +19,7 @@ from rospkg import RosPack
 from pilz_robot_programming.robot import *
 from pilz_industrial_motion_testutils.xml_testdata_loader import *
 from pilz_industrial_motion_testutils.integration_test_utils import *
+from pilz_industrial_motion_testutils.robot_motion_observer import RobotMotionObserver
 from pilz_robot_programming.commands import *
 
 _TEST_DATA_FILE_NAME = RosPack().get_path("pilz_industrial_motion_testutils") + "/test_data/testdata.xml"
@@ -45,6 +46,7 @@ class TestAPIExecutionStop(unittest.TestCase):
         rospy.loginfo("SetUp called...")
         self.test_data = XmlTestdataLoader(_TEST_DATA_FILE_NAME)
         self.robot = Robot(API_VERSION)
+        self.robot_motion_observer = RobotMotionObserver(PLANNING_GROUP_NAME)
 
     def tearDown(self):
         rospy.loginfo("TearDown called...")
@@ -138,7 +140,8 @@ class TestAPIExecutionStop(unittest.TestCase):
         # +++++++++++++++++++++++
 
         # Wait till movement started
-        wait_cmd_start(self.robot, self._SLEEP_TIME_S, self._TOLERANCE_FOR_MOTION_DETECTION_RAD)
+        self.assertTrue(self.robot_motion_observer.wait_motion_start(
+            move_tolerance=self._TOLERANCE_FOR_MOTION_DETECTION_RAD, sleep_interval=self._SLEEP_TIME_S))
 
         rospy.loginfo("Call stop function.")
         self.robot.stop()
@@ -415,7 +418,8 @@ class TestAPIExecutionStop(unittest.TestCase):
         # +++++++++++++++++++++++
 
         # Wait till movement started
-        wait_cmd_start(self.robot, self._SLEEP_TIME_S, self._TOLERANCE_FOR_MOTION_DETECTION_RAD)
+        self.assertTrue(self.robot_motion_observer.wait_motion_start(
+            move_tolerance=self._TOLERANCE_FOR_MOTION_DETECTION_RAD, sleep_interval=self._SLEEP_TIME_S))
 
         rospy.loginfo("Call stop function from external client.")
         move_client.cancel_all_goals()
@@ -452,7 +456,8 @@ class TestAPIExecutionStop(unittest.TestCase):
         # +++++++++++++++++++++++
 
         # Wait till movement started
-        wait_cmd_start(self.robot, self._SLEEP_TIME_S, self._TOLERANCE_FOR_MOTION_DETECTION_RAD)
+        self.assertTrue(self.robot_motion_observer.wait_motion_start(
+            move_tolerance=self._TOLERANCE_FOR_MOTION_DETECTION_RAD, sleep_interval=self._SLEEP_TIME_S))
 
         # start another command
         try:

--- a/pilz_robot_programming/test/integrationtests/tst_api_gripper.py
+++ b/pilz_robot_programming/test/integrationtests/tst_api_gripper.py
@@ -20,6 +20,7 @@ from pilz_robot_programming.robot import *
 from pilz_industrial_motion_testutils.xml_testdata_loader import *
 from pilz_robot_programming.commands import *
 from pilz_industrial_motion_testutils.integration_test_utils import *
+from pilz_industrial_motion_testutils.robot_motion_observer import RobotMotionObserver
 
 _TEST_DATA_FILE_NAME = RosPack().get_path("pilz_industrial_motion_testutils") + "/test_data/testdata.xml"
 API_VERSION = "1"
@@ -33,6 +34,7 @@ class TestAPIGripper(unittest.TestCase):
 
     def setUp(self):
         self.robot = Robot(API_VERSION)
+        self.robot_motion_observer = RobotMotionObserver("gripper")
         self.test_data = XmlTestdataLoader(_TEST_DATA_FILE_NAME)
 
     def tearDown(self):
@@ -137,7 +139,8 @@ class TestAPIGripper(unittest.TestCase):
 
         # 3
         # Wait till movement started
-        wait_cmd_start(self.robot, self._SLEEP_TIME_S, self._TOLERANCE_FOR_MOTION_DETECTION_RAD, "gripper")
+        self.assertTrue(self.robot_motion_observer.wait_motion_start(
+            move_tolerance=self._TOLERANCE_FOR_MOTION_DETECTION_RAD, sleep_interval=self._SLEEP_TIME_S))
 
         rospy.loginfo("Call stop function.")
         self.robot.stop()

--- a/pilz_robot_programming/test/integrationtests/tst_api_gripper.py
+++ b/pilz_robot_programming/test/integrationtests/tst_api_gripper.py
@@ -34,7 +34,7 @@ class TestAPIGripper(unittest.TestCase):
 
     def setUp(self):
         self.robot = Robot(API_VERSION)
-        self.robot_motion_observer = RobotMotionObserver("gripper")
+        self.robot_motion_observer = RobotMotionObserver(group_name="gripper")
         self.test_data = XmlTestdataLoader(_TEST_DATA_FILE_NAME)
 
     def tearDown(self):

--- a/pilz_robot_programming/test/integrationtests/tst_api_pause_concurrency.py
+++ b/pilz_robot_programming/test/integrationtests/tst_api_pause_concurrency.py
@@ -19,6 +19,7 @@ from rospkg import RosPack
 from pilz_robot_programming.robot import *
 from pilz_industrial_motion_testutils.xml_testdata_loader import *
 from pilz_industrial_motion_testutils.integration_test_utils import *
+from pilz_industrial_motion_testutils.robot_motion_observer import RobotMotionObserver
 from pilz_robot_programming.commands import *
 
 _TEST_DATA_FILE_NAME = RosPack().get_path("pilz_industrial_motion_testutils") + "/test_data/testdata.xml"
@@ -35,6 +36,7 @@ class TestAPIPauseConcurrency(unittest.TestCase):
     def setUp(self):
         self.test_data = XmlTestdataLoader(_TEST_DATA_FILE_NAME)
         self.robot = Robot(API_VERSION)
+        self.robot_motion_observer = RobotMotionObserver(PLANNING_GROUP_NAME)
         self.robot.move(Ptp(goal=self.test_data.get_joints("ZeroPose", PLANNING_GROUP_NAME)))
         self.ptp = Ptp(goal=self.test_data.get_joints("PTPJointLarge", PLANNING_GROUP_NAME))
 
@@ -73,7 +75,8 @@ class TestAPIPauseConcurrency(unittest.TestCase):
         with cv:
             cv.notify_all()
 
-        self.assertFalse(is_robot_moving(robot=self.robot))
+        self.assertFalse(self.robot_motion_observer.is_robot_moving(self._SLEEP_TIME_S,
+                                                                    self._TOLERANCE_FOR_MOTION_DETECTION_RAD))
 
         self.robot.resume()
 
@@ -97,12 +100,13 @@ class TestAPIPauseConcurrency(unittest.TestCase):
         # 1. start the robot motion
         move_thread = MoveThread(self.robot, self.ptp)
         move_thread.start()
-        wait_cmd_start(self.robot, self._SLEEP_TIME_S, self._TOLERANCE_FOR_MOTION_DETECTION_RAD)
+        self.assertTrue(self.robot_motion_observer.wait_motion_start(
+            move_tolerance=self._TOLERANCE_FOR_MOTION_DETECTION_RAD, sleep_interval=self._SLEEP_TIME_S))
 
         # 2. trigger pause
         self.robot.pause()
-        self.assertTrue(wait_cmd_stop(self.robot, self._WAIT_CMD_STOP_TIME_OUT_S,
-                                      self._TOLERANCE_FOR_MOTION_DETECTION_RAD))
+        self.assertTrue(self.robot_motion_observer.wait_motion_stop(self._WAIT_CMD_STOP_TIME_OUT_S,
+                                                                    self._TOLERANCE_FOR_MOTION_DETECTION_RAD))
 
         # 3. trigger stop/resume at the same time
         lock = threading.Lock()

--- a/pilz_robot_programming/test/integrationtests/tst_api_program_kill.py
+++ b/pilz_robot_programming/test/integrationtests/tst_api_program_kill.py
@@ -71,7 +71,7 @@ class TestAPIProgramKill(unittest.TestCase):
         proc = subprocess.Popen(self._get_robot_move_command())
 
         # Wait until movement is detected
-        self.robot_motion_observer.wait_motion_start()
+        self.assertTrue(self.robot_motion_observer.wait_motion_start())
 
         # 2. Send kill signal
         proc.send_signal(signal.SIGINT)

--- a/pilz_robot_programming/test/integrationtests/tst_api_program_kill.py
+++ b/pilz_robot_programming/test/integrationtests/tst_api_program_kill.py
@@ -33,6 +33,7 @@ class TestAPIProgramKill(unittest.TestCase):
     """
 
     _PTP_TEST_NAME = "PTPJointValid"
+    _WAIT_TIME_FOR_MOTION_DETECTION_SEC = 8.0
 
     def setUp(self):
         rospy.loginfo("SetUp called...")
@@ -71,7 +72,8 @@ class TestAPIProgramKill(unittest.TestCase):
         proc = subprocess.Popen(self._get_robot_move_command())
 
         # Wait until movement is detected
-        self.assertTrue(self.robot_motion_observer.wait_motion_start())
+        self.assertTrue(
+            self.robot_motion_observer.wait_motion_start(wait_time_out=self._WAIT_TIME_FOR_MOTION_DETECTION_SEC))
 
         # 2. Send kill signal
         proc.send_signal(signal.SIGINT)


### PR DESCRIPTION
A part of the integrationtest utility functions is replaced by the new test utility class `RobotMotionObserver`. A `RobotMotionObserver` object can detect, if the robot is moving and wait for a movement to start or to stop.
