### PR TITLE
add pilz_robot_programming to meta-package-depends

### DIFF
--- a/pilz_extensions/CHANGELOG.rst
+++ b/pilz_extensions/CHANGELOG.rst
@@ -2,6 +2,9 @@
 Changelog for package pilz_extensions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+Forthcoming
+-----------
+
 0.3.0 (2018-11-28)
 ------------------
 

--- a/pilz_industrial_motion/CHANGELOG.rst
+++ b/pilz_industrial_motion/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package pilz_industrial_motion
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+Forthcoming
+-----------
+* add pilz_robot_programming to depends of the meta-package
+* Contributors: Pilz GmbH and Co. KG
+
 0.3.0 (2018-11-28)
 ------------------
 

--- a/pilz_industrial_motion/package.xml
+++ b/pilz_industrial_motion/package.xml
@@ -16,6 +16,7 @@
   <exec_depend>pilz_extensions</exec_depend>
   <exec_depend>pilz_msgs</exec_depend>
   <exec_depend>pilz_trajectory_generation</exec_depend>
+  <exec_depend>pilz_robot_programming</exec_depend>
 
   <export>
     <metapackage/>

--- a/pilz_industrial_motion_testutils/CHANGELOG.rst
+++ b/pilz_industrial_motion_testutils/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package pilz_industrial_motion_testutils
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+Forthcoming
+-----------
+* Add RobotMotionObserver in testutils
+* Contributors: Pilz GmbH and Co. KG
+
 0.3.0 (2018-11-28)
 ------------------
 * rename get_current_joint_values -> get_current_joint_states

--- a/pilz_msgs/CHANGELOG.rst
+++ b/pilz_msgs/CHANGELOG.rst
@@ -2,6 +2,9 @@
 Changelog for package pilz_msgs
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+Forthcoming
+-----------
+
 0.3.0 (2018-11-28)
 ------------------
 * Renaming blend -> sequence

--- a/pilz_robot_programming/CHANGELOG.rst
+++ b/pilz_robot_programming/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package pilz_robot_programming
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+Forthcoming
+-----------
+* Add RobotMotionObserver in testutils
+* Contributors: Pilz GmbH and Co. KG
+
 0.3.0 (2018-11-28)
 ------------------
 * Release Python-API

--- a/pilz_robot_programming/package.xml
+++ b/pilz_robot_programming/package.xml
@@ -13,7 +13,6 @@
   <run_depend>moveit_commander</run_depend>
   <run_depend>tf</run_depend>
   <run_depend>rospy</run_depend>
-  <run_depend>python-docopt</run_depend>
   <run_depend>pilz_trajectory_generation</run_depend>
   <run_depend>pilz_msgs</run_depend>
 
@@ -22,6 +21,7 @@
   <build_depend>rospy</build_depend>
   <build_depend>roslint</build_depend>
 
+  <test_depend>python-docopt</test_depend>
   <test_depend>rostest</test_depend>
   <test_depend>prbt_moveit_config</test_depend>
   <test_depend>prbt_pg70_support</test_depend>

--- a/pilz_trajectory_generation/CHANGELOG.rst
+++ b/pilz_trajectory_generation/CHANGELOG.rst
@@ -2,6 +2,9 @@
 Changelog for package pilz_trajectory_generation
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+Forthcoming
+-----------
+
 0.3.0 (2018-11-28)
 ------------------
 * add append method for avoiding duplicate points in robot_trajectory trajectories


### PR DESCRIPTION
to install it together with `apt install pilz-industrial-motion`.
Changelogs updated.