### PR TITLE
Convert Eigen::Affine3d -> Eigen::Isometry3d.

### DIFF
--- a/pilz_industrial_motion_testutils/include/pilz_industrial_motion_testutils/motion_plan_request_director.h
+++ b/pilz_industrial_motion_testutils/include/pilz_industrial_motion_testutils/motion_plan_request_director.h
@@ -75,7 +75,7 @@ private:
    * @param pose
    * @return
    */
-  Eigen::Affine3d rawQuatVectorToEigen(const std::vector<double> &pose);
+  Eigen::Isometry3d rawQuatVectorToEigen(const std::vector<double> &pose);
 
   /**
    * @brief Construct a robot state from the start joint values in cmd.

--- a/pilz_industrial_motion_testutils/src/motion_plan_request_director.cpp
+++ b/pilz_industrial_motion_testutils/src/motion_plan_request_director.cpp
@@ -124,7 +124,7 @@ moveit_msgs::MotionPlanRequest MotionPlanRequestDirector::getCIRCCartReq(const m
   return builder.getRequest();
 }
 
-Eigen::Affine3d MotionPlanRequestDirector::rawQuatVectorToEigen(const std::vector<double>& pose)
+Eigen::Isometry3d MotionPlanRequestDirector::rawQuatVectorToEigen(const std::vector<double>& pose)
 {
   geometry_msgs::Pose pose_msg;
   pose_msg.position.x = pose.at(0);
@@ -135,7 +135,7 @@ Eigen::Affine3d MotionPlanRequestDirector::rawQuatVectorToEigen(const std::vecto
   pose_msg.orientation.z = pose.at(5);
   pose_msg.orientation.w = pose.at(6);
 
-  Eigen::Affine3d pose_eigen;
+  Eigen::Isometry3d pose_eigen;
   tf::poseMsgToEigen(pose_msg, pose_eigen);
   return pose_eigen;
 }
@@ -158,7 +158,7 @@ moveit::core::RobotState MotionPlanRequestDirector::getStartStateFromPose(
   robot_state::RobotState rstate = getStartStateFromJoints(robot_model, cmd);
 
   // set to Cartesian pose
-  Eigen::Affine3d start_pose = rawQuatVectorToEigen(cmd.start_pose);
+  Eigen::Isometry3d start_pose = rawQuatVectorToEigen(cmd.start_pose);
   if(!rstate.setFromIK(rstate.getRobotModel()->getJointModelGroup(cmd.planning_group), start_pose, cmd.target_link))
   {
     ROS_ERROR_STREAM("no solution for ik \n" << start_pose.translation() << "\n" << start_pose.linear());
@@ -185,7 +185,7 @@ moveit::core::RobotState MotionPlanRequestDirector::getGoalStateFromPose(
   robot_state::RobotState rstate = getGoalStateFromJoints(robot_model, cmd);
 
   // set to Cartesian pose
-  Eigen::Affine3d goal_pose = rawQuatVectorToEigen(cmd.goal_pose);
+  Eigen::Isometry3d goal_pose = rawQuatVectorToEigen(cmd.goal_pose);
   if(!rstate.setFromIK(rstate.getRobotModel()->getJointModelGroup(cmd.planning_group), goal_pose, cmd.target_link))
   {
     ROS_ERROR_STREAM("no solution for ik \n" << goal_pose.translation() << "\n" << goal_pose.linear());

--- a/pilz_trajectory_generation/include/pilz_trajectory_generation/trajectory_functions.h
+++ b/pilz_trajectory_generation/include/pilz_trajectory_generation/trajectory_functions.h
@@ -49,7 +49,7 @@ namespace pilz {
 bool computePoseIK(const robot_model::RobotModelConstPtr& robot_model,
                    const std::string& group_name,
                    const std::string& link_name,
-                   const Eigen::Affine3d& pose,
+                   const Eigen::Isometry3d& pose,
                    const std::string& frame_id,
                    const std::map<std::string, double>& seed,
                    std::map<std::string, double>& solution,
@@ -77,13 +77,13 @@ bool computePoseIK(const robot_model::RobotModelConstPtr& robot_model,
 bool computeLinkFK(const robot_model::RobotModelConstPtr& robot_model,
                    const std::string& link_name,
                    const std::map<std::string, double>& joint_state,
-                   Eigen::Affine3d& pose);
+                   Eigen::Isometry3d& pose);
 
 bool computeLinkFK(const robot_model::RobotModelConstPtr& robot_model,
                    const std::string& link_name,
                    const std::vector<std::string>& joint_names,
                    const std::vector<double>& joint_positions,
-                   Eigen::Affine3d& pose);
+                   Eigen::Isometry3d& pose);
 
 /**
  * @brief verify the velocity/acceleration limits of current sample (based on backward difference computation)

--- a/pilz_trajectory_generation/include/pilz_trajectory_generation/trajectory_generator.h
+++ b/pilz_trajectory_generation/include/pilz_trajectory_generation/trajectory_generator.h
@@ -67,8 +67,8 @@ protected:
   public:
     std::string group_name;
     std::string link_name;
-    Eigen::Affine3d start_pose;
-    Eigen::Affine3d goal_pose;
+    Eigen::Isometry3d start_pose;
+    Eigen::Isometry3d goal_pose;
     std::map<std::string, double> start_joint_position;
     std::map<std::string, double> goal_joint_position;
     std::pair<std::string, Eigen::Vector3d> circ_path_point;

--- a/pilz_trajectory_generation/src/trajectory_functions.cpp
+++ b/pilz_trajectory_generation/src/trajectory_functions.cpp
@@ -22,7 +22,7 @@
 bool pilz::computePoseIK(const moveit::core::RobotModelConstPtr &robot_model,
                          const std::string &group_name,
                          const std::string &link_name,
-                         const Eigen::Affine3d &pose,
+                         const Eigen::Isometry3d &pose,
                          const std::string &frame_id,
                          const std::map<std::string, double> &seed,
                          std::map<std::string, double> &solution,
@@ -106,7 +106,7 @@ bool pilz::computePoseIK(const moveit::core::RobotModelConstPtr &robot_model,
                          bool check_self_collision,
                          int max_attempt)
 {
-  Eigen::Affine3d pose_eigen;
+  Eigen::Isometry3d pose_eigen;
   tf::poseMsgToEigen(pose, pose_eigen);
   return computePoseIK(robot_model,
                        group_name,
@@ -122,7 +122,7 @@ bool pilz::computePoseIK(const moveit::core::RobotModelConstPtr &robot_model,
 bool pilz::computeLinkFK(const moveit::core::RobotModelConstPtr &robot_model,
                          const std::string &link_name,
                          const std::map<std::string, double> &joint_state,
-                         Eigen::Affine3d &pose)
+                         Eigen::Isometry3d &pose)
 {
   // create robot state
   robot_state::RobotState rstate(robot_model);
@@ -232,7 +232,7 @@ bool pilz::generateJointTrajectory(const moveit::core::RobotModelConstPtr &robot
   time_samples.push_back(trajectory.Duration());
 
   // sample the trajectory and solve the inverse kinematics
-  Eigen::Affine3d pose_sample;
+  Eigen::Isometry3d pose_sample;
   std::map<std::string, double> ik_solution_last, ik_solution, joint_velocity_last;
   ik_solution_last = initial_joint_position;
   for(const auto& item: ik_solution_last)

--- a/pilz_trajectory_generation/src/trajectory_generator_ptp.cpp
+++ b/pilz_trajectory_generation/src/trajectory_generator_ptp.cpp
@@ -265,7 +265,7 @@ bool TrajectoryGeneratorPTP::extractMotionPlanInfo(const planning_interface::Mot
     geometry_msgs::Pose pose;
     pose.position = p;
     pose.orientation = req.goal_constraints.at(0).orientation_constraints.at(0).orientation;
-    Eigen::Affine3d pose_eigen;
+    Eigen::Isometry3d pose_eigen;
     tf::poseMsgToEigen(pose,pose_eigen);
     if(!computePoseIK(robot_model_,
                       req.group_name,

--- a/pilz_trajectory_generation/test/unittest_planning_context.cpp
+++ b/pilz_trajectory_generation/test/unittest_planning_context.cpp
@@ -124,14 +124,14 @@ protected:
     // state state in joint space, used as initial positions, since IK does not work at zero positions
     rstate.setJointGroupPositions(this->planning_group_, {4.430233957464225e-12, 0.007881892504574495, -1.8157263253868452,
                                  1.1801525390026025e-11, 1.8236082178909834, 8.591793942969161e-12});
-    Eigen::Affine3d start_pose(Eigen::Affine3d::Identity());
+    Eigen::Isometry3d start_pose(Eigen::Isometry3d::Identity());
     start_pose.translation() = Eigen::Vector3d(0.3, 0, 0.65);
     rstate.setFromIK(this->robot_model_->getJointModelGroup(this->planning_group_),
                      start_pose);
     moveit::core::robotStateToRobotStateMsg(rstate,req.start_state,false);
 
     // goal constraint
-    Eigen::Affine3d goal_pose(Eigen::Affine3d::Identity());
+    Eigen::Isometry3d goal_pose(Eigen::Isometry3d::Identity());
     goal_pose.translation() = Eigen::Vector3d(0, 0.3, 0.65);
     Eigen::Matrix3d goal_rotation;
     goal_rotation = Eigen::AngleAxisd(0*M_PI, Eigen::Vector3d::UnitZ());

--- a/pilz_trajectory_generation/test/unittest_trajectory_functions.cpp
+++ b/pilz_trajectory_generation/test/unittest_trajectory_functions.cpp
@@ -146,7 +146,7 @@ INSTANTIATE_TEST_CASE_P(InstantiationName, TrajectoryFunctionsTest, ::testing::V
  */
 TEST_P(TrajectoryFunctionsTest, TipLinkFK)
 {
-  Eigen::Affine3d tip_pose;
+  Eigen::Isometry3d tip_pose;
   std::map<std::string, double> test_state = zero_state_;
   EXPECT_TRUE(pilz::computeLinkFK(robot_model_, group_tip_link_, test_state, tip_pose));
   EXPECT_NEAR(tip_pose(0,3),0,EPSILON);
@@ -245,7 +245,7 @@ TEST_P(TrajectoryFunctionsTest, testIKRobotState)
     // sample random robot state
     rstate.setToRandomPositions(jmg, rng_);
 
-    Eigen::Affine3d pose_expect = rstate.getFrameTransform(tcp_link_);
+    Eigen::Isometry3d pose_expect = rstate.getFrameTransform(tcp_link_);
 
     // copy the random state and set ik seed
     std::map<std::string, double> ik_seed, ik_expect;
@@ -305,7 +305,7 @@ TEST_P(TrajectoryFunctionsTest, testComputePoseIK)
     // sample random robot state
     rstate.setToRandomPositions(jmg, rng_);
 
-    Eigen::Affine3d pose_expect = rstate.getFrameTransform(tcp_link_);
+    Eigen::Isometry3d pose_expect = rstate.getFrameTransform(tcp_link_);
 
     // copy the random state and set ik seed
     std::map<std::string, double> ik_seed, ik_expect;
@@ -356,7 +356,7 @@ TEST_P(TrajectoryFunctionsTest, testComputePoseIK)
 TEST_P(TrajectoryFunctionsTest, testComputePoseIKInvalidGroupName)
 {
   const std::string frame_id = robot_model_->getModelFrame();
-  Eigen::Affine3d pose_expect;
+  Eigen::Isometry3d pose_expect;
 
   std::map<std::string, double> ik_seed;
 
@@ -378,7 +378,7 @@ TEST_P(TrajectoryFunctionsTest, testComputePoseIKInvalidGroupName)
 TEST_P(TrajectoryFunctionsTest, testComputePoseIKInvalidLinkName)
 {
   const std::string frame_id = robot_model_->getModelFrame();
-  Eigen::Affine3d pose_expect;
+  Eigen::Isometry3d pose_expect;
 
   std::map<std::string, double> ik_seed;
 
@@ -401,7 +401,7 @@ TEST_P(TrajectoryFunctionsTest, testComputePoseIKInvalidLinkName)
  */
 TEST_P(TrajectoryFunctionsTest, testComputePoseIKInvalidFrameId)
 {
-  Eigen::Affine3d pose_expect;
+  Eigen::Isometry3d pose_expect;
 
   std::map<std::string, double> ik_seed;
 


### PR DESCRIPTION
This is to keep up with the recent changes in moveit
(https://github.com/ros-planning/moveit/pull/1096) and
keep this package building in melodic (it is currently failing; see http://build.ros.org/view/Mbin_uB64/job/Mbin_uB64__pilz_industrial_motion_testutils__ubuntu_bionic_amd64__binary/)