### PR TITLE
Fix #16: adjust start pose for panda integration tests

### DIFF
--- a/pilz_trajectory_generation/CMakeLists.txt
+++ b/pilz_trajectory_generation/CMakeLists.txt
@@ -266,8 +266,8 @@ add_rostest(test/integrationtest_command_planning_with_gripper.test
 add_rostest(test/integrationtest_command_planning_abb_irb2400.test
   DEPENDENCIES integrationtest_command_planning )
 
-#add_rostest(test/integrationtest_command_planning_frankaemika_panda.test
-#  DEPENDENCIES integrationtest_command_planning )
+add_rostest(test/integrationtest_command_planning_frankaemika_panda.test
+  DEPENDENCIES integrationtest_command_planning )
 
 # Blending Integration tests
 add_rostest_gtest(integrationtest_command_list_manager

--- a/pilz_trajectory_generation/test/test_robots/frankaemika_panda/test_data/testdata.xml
+++ b/pilz_trajectory_generation/test/test_robots/frankaemika_panda/test_data/testdata.xml
@@ -23,7 +23,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
     <pos name="ZeroPose">
         <group name="panda_arm">
-            <joints>0.0 0.0 0.0 -1.5708 0.0 0.0 0.0</joints>
+            <joints>0.0 0.0 0.0 -1.5708 0.0 1.5708 0.0</joints>
         </group>
     </pos>
 


### PR DESCRIPTION
Fixes #16. Link 5 and 7 had a collision (collision check was disabled before in panda_moveit_config).

We can port this to melodic, too.