### PR TITLE
Set pipeline in test to command_planner

### DIFF
--- a/pilz_robot_programming/test/integrationtests/integrationtest_self_collision.test
+++ b/pilz_robot_programming/test/integrationtests/integrationtest_self_collision.test
@@ -35,8 +35,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
     <arg name="info" value="true"/>
     <arg name="debug" value="false"/>
     <arg name="gripper" value="pg70"/>
-    <arg name="capabilities" value="pilz_trajectory_generation/MoveGroupSequenceAction
-                                    pilz_trajectory_generation/MoveGroupSequenceService" />
+    <arg name="pipeline" value="command_planner" />
   </include>
 
   <!-- test node -->

--- a/pilz_robot_programming/test/integrationtests/tst_api_cmd_conversion.test
+++ b/pilz_robot_programming/test/integrationtests/tst_api_cmd_conversion.test
@@ -34,8 +34,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
     <arg name="fake_execution" value="true"/>
     <arg name="info" value="true"/>
     <arg name="debug" value="$(arg debug)"/>
-    <arg name="capabilities" value="pilz_trajectory_generation/MoveGroupSequenceAction
-                                    pilz_trajectory_generation/MoveGroupSequenceService"/>
+    <arg name="pipeline" value="command_planner" />
   </include>
 
   <!-- test node -->

--- a/pilz_robot_programming/test/integrationtests/tst_api_cmd_conversion_with_gripper.test
+++ b/pilz_robot_programming/test/integrationtests/tst_api_cmd_conversion_with_gripper.test
@@ -36,8 +36,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
     <arg name="info" value="true"/>
     <arg name="debug" value="$(arg debug)"/>
     <arg name="gripper" value="$(arg gripper)"/>
-    <arg name="capabilities" value="pilz_trajectory_generation/MoveGroupSequenceAction
-                                    pilz_trajectory_generation/MoveGroupSequenceService" />
+    <arg name="pipeline" value="command_planner" />
   </include>
 
   <!-- test node -->

--- a/pilz_robot_programming/test/integrationtests/tst_api_execution_stop.test
+++ b/pilz_robot_programming/test/integrationtests/tst_api_execution_stop.test
@@ -36,8 +36,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
     <arg name="fake_execution" value="true"/>
     <arg name="info" value="true"/>
     <arg name="debug" value="$(arg debug)"/>
-    <arg name="capabilities" value="pilz_trajectory_generation/MoveGroupSequenceAction
-                                    pilz_trajectory_generation/MoveGroupSequenceService"/>
+    <arg name="pipeline" value="command_planner" />
   </include>
 
   <!-- test node -->

--- a/pilz_robot_programming/test/integrationtests/tst_api_execution_stop_with_gripper.test
+++ b/pilz_robot_programming/test/integrationtests/tst_api_execution_stop_with_gripper.test
@@ -38,8 +38,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
     <arg name="info" value="true"/>
     <arg name="debug" value="$(arg debug)"/>
     <arg name="gripper" value="$(arg gripper)"/>
-    <arg name="capabilities" value="pilz_trajectory_generation/MoveGroupSequenceAction
-                                    pilz_trajectory_generation/MoveGroupSequenceService" />
+    <arg name="pipeline" value="command_planner" />
   </include>
 
   <!-- test node -->

--- a/pilz_robot_programming/test/integrationtests/tst_api_gripper.test
+++ b/pilz_robot_programming/test/integrationtests/tst_api_gripper.test
@@ -36,8 +36,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
     <arg name="info" value="true"/>
     <arg name="debug" value="$(arg debug)"/>
     <arg name="gripper" value="$(arg gripper)"/>
-    <arg name="capabilities" value="pilz_trajectory_generation/MoveGroupSequenceAction
-                                    pilz_trajectory_generation/MoveGroupSequenceService" />
+    <arg name="pipeline" value="command_planner" />
   </include>
 
   <!-- test node -->

--- a/pilz_robot_programming/test/integrationtests/tst_api_instantiation.test
+++ b/pilz_robot_programming/test/integrationtests/tst_api_instantiation.test
@@ -34,8 +34,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
     <arg name="fake_execution" value="true"/>
     <arg name="info" value="true"/>
     <arg name="debug" value="$(arg debug)"/>
-    <arg name="capabilities" value="pilz_trajectory_generation/MoveGroupSequenceAction
-                                    pilz_trajectory_generation/MoveGroupSequenceService"/>
+    <arg name="pipeline" value="command_planner" />
   </include>
 
   <!-- test node -->

--- a/pilz_robot_programming/test/integrationtests/tst_api_pause.test
+++ b/pilz_robot_programming/test/integrationtests/tst_api_pause.test
@@ -36,8 +36,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
     <arg name="fake_execution" value="true"/>
     <arg name="info" value="true"/>
     <arg name="debug" value="$(arg debug)"/>
-    <arg name="capabilities" value="pilz_trajectory_generation/MoveGroupSequenceAction
-                                    pilz_trajectory_generation/MoveGroupSequenceService"/>
+    <arg name="pipeline" value="command_planner" />
   </include>
 
   <!-- test node -->

--- a/pilz_robot_programming/test/integrationtests/tst_api_pause_concurrency.test
+++ b/pilz_robot_programming/test/integrationtests/tst_api_pause_concurrency.test
@@ -36,8 +36,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
     <arg name="fake_execution" value="true"/>
     <arg name="info" value="true"/>
     <arg name="debug" value="$(arg debug)"/>
-    <arg name="capabilities" value="pilz_trajectory_generation/MoveGroupSequenceAction
-                                    pilz_trajectory_generation/MoveGroupSequenceService"/>
+    <arg name="pipeline" value="command_planner" />
   </include>
 
   <!-- test node -->

--- a/pilz_robot_programming/test/integrationtests/tst_api_program_kill.test
+++ b/pilz_robot_programming/test/integrationtests/tst_api_program_kill.test
@@ -39,8 +39,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
     <arg name="info" value="true"/>
     <arg name="debug" value="$(arg debug)"/>
     <arg name="gripper" value="$(arg gripper)"/>
-    <arg name="capabilities" value="pilz_trajectory_generation/MoveGroupSequenceAction
-                                    pilz_trajectory_generation/MoveGroupSequenceService"/>
+    <arg name="pipeline" value="command_planner" />
   </include>
 
   <!-- test node -->

--- a/pilz_robot_programming/test/integrationtests/tst_api_utility_functions.test
+++ b/pilz_robot_programming/test/integrationtests/tst_api_utility_functions.test
@@ -34,8 +34,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
     <arg name="fake_execution" value="true"/>
     <arg name="info" value="true"/>
     <arg name="debug" value="$(arg debug)"/>
-    <arg name="capabilities" value="pilz_trajectory_generation/MoveGroupSequenceAction
-                                    pilz_trajectory_generation/MoveGroupSequenceService"/>
+    <arg name="pipeline" value="command_planner" />
   </include>
 
   <!-- test node -->

--- a/pilz_trajectory_generation/test/integrationtest_command_planning.test
+++ b/pilz_trajectory_generation/test/integrationtest_command_planning.test
@@ -30,8 +30,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
     <arg name="fake_execution" value="true"/>
     <arg name="info" value="true"/>
     <arg name="debug" value="$(arg debug)"/>
-    <arg name="capabilities" value="pilz_trajectory_generation/MoveGroupSequenceAction
-                                    pilz_trajectory_generation/MoveGroupSequenceService"/>
+    <arg name="pipeline" value="command_planner" />
   </include>
 
   <!-- run test -->

--- a/pilz_trajectory_generation/test/integrationtest_command_planning_with_gripper.test
+++ b/pilz_trajectory_generation/test/integrationtest_command_planning_with_gripper.test
@@ -29,8 +29,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
     <arg name="fake_execution" value="true"/>
     <arg name="info" value="true"/>
     <arg name="gripper" value="pg70"/>
-    <arg name="capabilities" value="pilz_trajectory_generation/MoveGroupSequenceAction
-                                    pilz_trajectory_generation/MoveGroupSequenceService"/>
+    <arg name="pipeline" value="command_planner" />
   </include>
 
   <!-- run test -->

--- a/pilz_trajectory_generation/test/integrationtest_sequence_action_capability.test
+++ b/pilz_trajectory_generation/test/integrationtest_sequence_action_capability.test
@@ -32,7 +32,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
     <arg name="fake_execution" value="true"/>
     <arg name="info" value="true"/>
     <arg name="debug" value="$(arg debug)"/>
-    <arg name="capabilities" value="pilz_trajectory_generation/MoveGroupSequenceAction" />
+    <arg name="pipeline" value="command_planner" />
   </include>
 
   <!-- run test -->

--- a/pilz_trajectory_generation/test/integrationtest_sequence_action_capability_with_gripper.test
+++ b/pilz_trajectory_generation/test/integrationtest_sequence_action_capability_with_gripper.test
@@ -29,7 +29,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
     <arg name="fake_execution" value="true"/>
     <arg name="info" value="true"/>
     <arg name="gripper" value="pg70"/>
-    <arg name="capabilities" value="pilz_trajectory_generation/MoveGroupSequenceAction" />
+    <arg name="pipeline" value="command_planner" />
   </include>
 
   <!-- run test -->

--- a/pilz_trajectory_generation/test/integrationtest_sequence_service_capability.test
+++ b/pilz_trajectory_generation/test/integrationtest_sequence_service_capability.test
@@ -32,7 +32,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
     <arg name="fake_execution" value="true"/>
     <arg name="info" value="true"/>
     <arg name="debug" value="$(arg debug)"/>
-    <arg name="capabilities" value="pilz_trajectory_generation/MoveGroupSequenceService" />
+    <arg name="pipeline" value="command_planner" />
   </include>
 
   <!-- run test -->

--- a/pilz_trajectory_generation/test/integrationtest_sequence_service_capability_with_gripper.test
+++ b/pilz_trajectory_generation/test/integrationtest_sequence_service_capability_with_gripper.test
@@ -31,7 +31,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
     <arg name="fake_execution" value="true"/>
     <arg name="info" value="true"/>
     <arg name="gripper" value="pg70"/>
-    <arg name="capabilities" value="pilz_trajectory_generation/MoveGroupSequenceService" />
+    <arg name="pipeline" value="command_planner" />
   </include>
 
   <!-- run test -->


### PR DESCRIPTION
* Needed due to https://github.com/PilzDE/pilz_robots/commit/eb203fdbc63503d53c2cfe956dc2a1c0d5fb7470
* Sets the pipeline instead of directly specifying the capabilities