### PR TITLE
Increase too optimistic IK timeout causing unstable tests in CI

### DIFF
--- a/pilz_trajectory_generation/include/pilz_trajectory_generation/trajectory_functions.h
+++ b/pilz_trajectory_generation/include/pilz_trajectory_generation/trajectory_functions.h
@@ -55,7 +55,7 @@ bool computePoseIK(const robot_model::RobotModelConstPtr& robot_model,
                    std::map<std::string, double>& solution,
                    bool check_self_collision = true,
                    int max_attempt = 10,
-                   const double timeout = 0.005);
+                   const double timeout = 0.1);
 
 bool computePoseIK(const robot_model::RobotModelConstPtr& robot_model,
                    const std::string& group_name,
@@ -66,7 +66,7 @@ bool computePoseIK(const robot_model::RobotModelConstPtr& robot_model,
                    std::map<std::string, double>& solution,
                    bool check_self_collision = true,
                    int max_attempt = 10,
-                   const double timeout = 0.005);
+                   const double timeout = 0.1);
 
 /**
  * @brief compute the pose of a link at give robot state

--- a/pilz_trajectory_generation/test/integrationtest_command_planning.cpp
+++ b/pilz_trajectory_generation/test/integrationtest_command_planning.cpp
@@ -135,11 +135,11 @@ TEST_F(IntegrationTestCommandPlanning, PTPJointGoal)
   srv.request.motion_plan_request.group_name = planning_group_;
   srv.request.motion_plan_request.planner_id = "PTP";
 
-  ros::service::waitForService(PLAN_SERVICE_NAME, ros::Duration(10));
+  ASSERT_TRUE(ros::service::waitForService(PLAN_SERVICE_NAME, ros::Duration(testutils::DEFAULT_SERVICE_TIMEOUT)));
   ros::ServiceClient client = node_handle.serviceClient<moveit_msgs::GetMotionPlan>(PLAN_SERVICE_NAME);
 
   // Call the service client
-  client.call(srv);
+  ASSERT_TRUE(client.call(srv));
 
   // Obtain the response
   const moveit_msgs::MotionPlanResponse& response = srv.response.motion_plan_response;
@@ -223,11 +223,11 @@ TEST_F(IntegrationTestCommandPlanning, PTPPoseGoal)
   srv.request.motion_plan_request.group_name = planning_group_;
   srv.request.motion_plan_request.planner_id = "PTP";
 
-  ros::service::waitForService(PLAN_SERVICE_NAME, ros::Duration(10));
+  ASSERT_TRUE(ros::service::waitForService(PLAN_SERVICE_NAME, ros::Duration(testutils::DEFAULT_SERVICE_TIMEOUT)));
   ros::ServiceClient client = node_handle.serviceClient<moveit_msgs::GetMotionPlan>(PLAN_SERVICE_NAME);
 
   // Call the service client
-  client.call(srv);
+  ASSERT_TRUE(client.call(srv));
 
   // Obtain the response
   const moveit_msgs::MotionPlanResponse& response = srv.response.motion_plan_response;
@@ -320,11 +320,11 @@ TEST_F(IntegrationTestCommandPlanning, LinJointGoal)
   moveit_msgs::GetMotionPlan srv;
   srv.request.motion_plan_request = req;
 
-  ros::service::waitForService(PLAN_SERVICE_NAME, ros::Duration(testutils::DEFAULT_SERVICE_TIMEOUT));
+  ASSERT_TRUE(ros::service::waitForService(PLAN_SERVICE_NAME, ros::Duration(testutils::DEFAULT_SERVICE_TIMEOUT)));
   ros::ServiceClient client = node_handle.serviceClient<moveit_msgs::GetMotionPlan>(PLAN_SERVICE_NAME);
 
   // Call the service client
-  client.call(srv);
+  ASSERT_TRUE(client.call(srv));
 
   // Obtain the response
   const moveit_msgs::MotionPlanResponse& response = srv.response.motion_plan_response;
@@ -408,11 +408,11 @@ TEST_F(IntegrationTestCommandPlanning, LinPoseGoal)
   moveit_msgs::GetMotionPlan srv;
   srv.request.motion_plan_request = req;
 
-  ros::service::waitForService(PLAN_SERVICE_NAME, ros::Duration(testutils::DEFAULT_SERVICE_TIMEOUT));
+  ASSERT_TRUE(ros::service::waitForService(PLAN_SERVICE_NAME, ros::Duration(testutils::DEFAULT_SERVICE_TIMEOUT)));
   ros::ServiceClient client = node_handle.serviceClient<moveit_msgs::GetMotionPlan>(PLAN_SERVICE_NAME);
 
   // Call the service client
-  client.call(srv);
+  ASSERT_TRUE(client.call(srv));
 
   // Obtain the response
   const moveit_msgs::MotionPlanResponse& response = srv.response.motion_plan_response;
@@ -470,11 +470,11 @@ TEST_F(IntegrationTestCommandPlanning, CIRCJointGoal)
   moveit_msgs::GetMotionPlan srv;
   srv.request.motion_plan_request = req;
 
-  ros::service::waitForService(PLAN_SERVICE_NAME, ros::Duration(10));
+  ASSERT_TRUE(ros::service::waitForService(PLAN_SERVICE_NAME, ros::Duration(testutils::DEFAULT_SERVICE_TIMEOUT)));
   ros::ServiceClient client = node_handle.serviceClient<moveit_msgs::GetMotionPlan>(PLAN_SERVICE_NAME);
 
   // Call the service client
-  client.call(srv);
+  ASSERT_TRUE(client.call(srv));
 
   // Obtain the response
   const moveit_msgs::MotionPlanResponse& response = srv.response.motion_plan_response;
@@ -559,11 +559,11 @@ TEST_F(IntegrationTestCommandPlanning, CIRCPoseGoal)
   moveit_msgs::GetMotionPlan srv;
   srv.request.motion_plan_request = req;
 
-  ros::service::waitForService(PLAN_SERVICE_NAME, ros::Duration(10));
+  ASSERT_TRUE(ros::service::waitForService(PLAN_SERVICE_NAME, ros::Duration(testutils::DEFAULT_SERVICE_TIMEOUT)));
   ros::ServiceClient client = node_handle.serviceClient<moveit_msgs::GetMotionPlan>(PLAN_SERVICE_NAME);
 
   // Call the service client
-  client.call(srv);
+  ASSERT_TRUE(client.call(srv));
 
   // Obtain the response
   const moveit_msgs::MotionPlanResponse& response = srv.response.motion_plan_response;
@@ -629,5 +629,6 @@ int main(int argc, char **argv)
 {
   testing::InitGoogleTest(&argc, argv);
   ros::init(argc, argv, "integrationtest_command_planning");
+  ros::NodeHandle nh; // For output via ROS_ERROR etc during test
   return RUN_ALL_TESTS();
 }


### PR DESCRIPTION
Make sure that services are up before using them. Tests need to be aborted if not.