### PR TITLE
Use suited error codes for invalid motion plans

### DIFF
--- a/pilz_trajectory_generation/src/command_list_manager.cpp
+++ b/pilz_trajectory_generation/src/command_list_manager.cpp
@@ -98,7 +98,7 @@ bool CommandListManager::solve(const planning_scene::PlanningSceneConstPtr& plan
   if(!validateBlendingRadiiDoNotOverlap(motion_plan_responses, radii, group_name))
   {
     res.trajectory_.reset(new robot_trajectory::RobotTrajectory(model_, 0));
-    res.error_code_.val = moveit_msgs::MoveItErrorCodes::FAILURE;
+    res.error_code_.val = moveit_msgs::MoveItErrorCodes::INVALID_MOTION_PLAN;
     return false;
   }
 
@@ -145,7 +145,7 @@ bool CommandListManager::validateRequestList(const pilz_msgs::MotionSequenceRequ
   {
     ROS_ERROR_STREAM("Cannot blend. All requests MUST be about the same group!");
     res.trajectory_.reset(new robot_trajectory::RobotTrajectory(model_, 0));
-    res.error_code_.val = moveit_msgs::MoveItErrorCodes::FAILURE;
+    res.error_code_.val = moveit_msgs::MoveItErrorCodes::INVALID_GROUP_NAME;
     return false;
   }
 
@@ -155,7 +155,7 @@ bool CommandListManager::validateRequestList(const pilz_msgs::MotionSequenceRequ
   {
     ROS_ERROR_STREAM("Cannot blend. All blending radii MUST be non negative!");
     res.trajectory_.reset(new robot_trajectory::RobotTrajectory(model_, 0));
-    res.error_code_.val = moveit_msgs::MoveItErrorCodes::FAILURE;
+    res.error_code_.val = moveit_msgs::MoveItErrorCodes::INVALID_MOTION_PLAN;
     return false;
   }
 
@@ -164,7 +164,7 @@ bool CommandListManager::validateRequestList(const pilz_msgs::MotionSequenceRequ
   {
     ROS_ERROR_STREAM("Cannot blend. The last blending radius must be zero!");
     res.trajectory_.reset(new robot_trajectory::RobotTrajectory(model_, 0));
-    res.error_code_.val = moveit_msgs::MoveItErrorCodes::FAILURE;
+    res.error_code_.val = moveit_msgs::MoveItErrorCodes::INVALID_MOTION_PLAN;
     return false;
   }
 
@@ -180,7 +180,7 @@ bool CommandListManager::validateRequestList(const pilz_msgs::MotionSequenceRequ
   {
     ROS_ERROR_STREAM("Cannot blend. Only the first request is allowed to have a start state!");
     res.trajectory_.reset(new robot_trajectory::RobotTrajectory(model_, 0));
-    res.error_code_.val = moveit_msgs::MoveItErrorCodes::START_STATE_VIOLATES_PATH_CONSTRAINTS;
+    res.error_code_.val = moveit_msgs::MoveItErrorCodes::INVALID_ROBOT_STATE;
     return false;
   }
 

--- a/pilz_trajectory_generation/test/integrationtest_command_list_manager.cpp
+++ b/pilz_trajectory_generation/test/integrationtest_command_list_manager.cpp
@@ -381,7 +381,7 @@ TEST_P(IntegrationTestCommandListManager, startStateNotFirstGoal)
   req.items[1].req.start_state.joint_state = testutils::generateJointState({-1., 2., -3., 4., -5., 0.});
   planning_interface::MotionPlanResponse res;
   ASSERT_FALSE(manager_->solve(scene_, req, res));
-  EXPECT_EQ(moveit_msgs::MoveItErrorCodes::START_STATE_VIOLATES_PATH_CONSTRAINTS, res.error_code_.val);
+  EXPECT_EQ(moveit_msgs::MoveItErrorCodes::INVALID_ROBOT_STATE, res.error_code_.val);
   EXPECT_EQ(0u, res.trajectory_->getWayPointCount());
 }
 
@@ -402,7 +402,7 @@ TEST_P(IntegrationTestCommandListManager, blendingRadiusNegative)
   req.items[0].blend_radius = -0.3;
   planning_interface::MotionPlanResponse res;
   ASSERT_FALSE(manager_->solve(scene_, req, res));
-  EXPECT_EQ(moveit_msgs::MoveItErrorCodes::FAILURE, res.error_code_.val);
+  EXPECT_EQ(moveit_msgs::MoveItErrorCodes::INVALID_MOTION_PLAN, res.error_code_.val);
   EXPECT_EQ(0u, res.trajectory_->getWayPointCount());
 }
 
@@ -423,7 +423,7 @@ TEST_P(IntegrationTestCommandListManager, lastBlendingRadiusNonZero)
   req.items[1].blend_radius = 0.03;
   planning_interface::MotionPlanResponse res;
   ASSERT_FALSE(manager_->solve(scene_, req, res));
-  EXPECT_EQ(moveit_msgs::MoveItErrorCodes::FAILURE, res.error_code_.val);
+  EXPECT_EQ(moveit_msgs::MoveItErrorCodes::INVALID_MOTION_PLAN, res.error_code_.val);
   EXPECT_EQ(0u, res.trajectory_->getWayPointCount());
 }
 
@@ -479,7 +479,7 @@ TEST_P(IntegrationTestCommandListManager, blendingRadiusOverlapping)
   auto distance = (p2.translation()-p1.translation()).norm();
   req.items[1].blend_radius = distance - req.items[0].blend_radius + 0.01; // overlapping radii
   ASSERT_FALSE(manager_->solve(scene_, req, res_overlap));
-  EXPECT_EQ(moveit_msgs::MoveItErrorCodes::FAILURE, res_overlap.error_code_.val);
+  EXPECT_EQ(moveit_msgs::MoveItErrorCodes::INVALID_MOTION_PLAN, res_overlap.error_code_.val);
   EXPECT_EQ(0u, res_overlap.trajectory_->getWayPointCount());
 }
 

--- a/pilz_trajectory_generation/test/integrationtest_sequence_action_capability.cpp
+++ b/pilz_trajectory_generation/test/integrationtest_sequence_action_capability.cpp
@@ -213,7 +213,7 @@ TEST_F(IntegrationTestSequenceAction, blendLINLINInvalidGroupnames)
     // send goal
     ac_blend_.sendGoalAndWait(seq_goal);
     pilz_msgs::MoveGroupSequenceResultConstPtr res = ac_blend_.getResult();
-    EXPECT_EQ(res->error_code.val, moveit_msgs::MoveItErrorCodes::FAILURE) << "Blend failed.";
+    EXPECT_EQ(res->error_code.val, moveit_msgs::MoveItErrorCodes::INVALID_GROUP_NAME) << "Blend failed.";
     EXPECT_EQ(res->planned_trajectory.joint_trajectory.points.size(), 0u)
         << "Planned trajectory is empty.";
   }
@@ -253,7 +253,7 @@ TEST_F(IntegrationTestSequenceAction, blendLINLIN_invalidBlendRadius)
     // send goal
     ac_blend_.sendGoalAndWait(seq_goal);
     pilz_msgs::MoveGroupSequenceResultConstPtr res = ac_blend_.getResult();
-    EXPECT_EQ(res->error_code.val, moveit_msgs::MoveItErrorCodes::FAILURE) << "Blend failed.";
+    EXPECT_EQ(res->error_code.val, moveit_msgs::MoveItErrorCodes::INVALID_MOTION_PLAN) << "Blend failed.";
     EXPECT_EQ(res->planned_trajectory.joint_trajectory.points.size(), 0u)
         << "Planned trajectory is empty.";
   }

--- a/pilz_trajectory_generation/test/integrationtest_sequence_service_capability.cpp
+++ b/pilz_trajectory_generation/test/integrationtest_sequence_service_capability.cpp
@@ -201,7 +201,8 @@ TEST_F(IntegrationTestSequenceService, blendRadiusNegative)
   // Obtain the response
   const moveit_msgs::MotionPlanResponse& response = srv.response.plan_response;
 
-  EXPECT_EQ(moveit_msgs::MoveItErrorCodes::FAILURE, response.error_code.val) << "Planning should have failed but did not.";
+  EXPECT_EQ(moveit_msgs::MoveItErrorCodes::INVALID_MOTION_PLAN, response.error_code.val)
+    << "Planning should have failed but did not.";
   EXPECT_EQ(0u, response.trajectory.joint_trajectory.points.size()) << "Trajectory should not contain any points.";
 }
 
@@ -259,7 +260,7 @@ TEST_F(IntegrationTestSequenceService, startStateNotFirstGoal)
   // Obtain the response
   const moveit_msgs::MotionPlanResponse& response = srv.response.plan_response;
 
-  EXPECT_EQ(moveit_msgs::MoveItErrorCodes::START_STATE_VIOLATES_PATH_CONSTRAINTS, response.error_code.val) << "Incorrect error code.";
+  EXPECT_EQ(moveit_msgs::MoveItErrorCodes::INVALID_ROBOT_STATE, response.error_code.val) << "Incorrect error code.";
   EXPECT_EQ(0u, response.trajectory.joint_trajectory.points.size()) << "Trajectory should not contain any points.";
 }
 


### PR DESCRIPTION
It is never checked if a start state violates the path constraints, but an error is thrown if it is non-empty.