### PR TITLE
Refactor blendLINLINcb test using gmock and async_test

### DIFF
--- a/pilz_trajectory_generation/CMakeLists.txt
+++ b/pilz_trajectory_generation/CMakeLists.txt
@@ -23,6 +23,7 @@ find_package(catkin REQUIRED COMPONENTS
   moveit_ros_move_group
   moveit_ros_planning_interface
   pilz_industrial_motion_testutils
+  pilz_testutils
 )
 
 
@@ -223,7 +224,7 @@ add_dependencies(${PROJECT_NAME}_test
 #########################
 
 # Planning Integration tests
-add_rostest_gtest(integrationtest_sequence_action_capability
+add_rostest_gmock(integrationtest_sequence_action_capability
   test/integrationtest_sequence_action_capability.test
   test/integrationtest_sequence_action_capability.cpp
 )
@@ -231,7 +232,7 @@ add_rostest_gtest(integrationtest_sequence_action_capability
 target_link_libraries(integrationtest_sequence_action_capability
    ${catkin_LIBRARIES} ${PROJECT_NAME}_test)
 
-add_rostest_gtest(integrationtest_sequence_action_capability_with_gripper
+add_rostest_gmock(integrationtest_sequence_action_capability_with_gripper
   test/integrationtest_sequence_action_capability_with_gripper.test
   test/integrationtest_sequence_action_capability.cpp
 )

--- a/pilz_trajectory_generation/package.xml
+++ b/pilz_trajectory_generation/package.xml
@@ -56,6 +56,7 @@
   <test_depend>panda_moveit_config</test_depend>
   <test_depend>abb_irb2400_moveit_config</test_depend>
   <test_depend>code_coverage</test_depend>
+  <test_depend>pilz_testutils</test_depend>
 
 
   <!-- The export tag contains other, unspecified, tags -->


### PR DESCRIPTION
* waitForResult() was out of place here. When testing the sendGoal method with callbacks,
async_test provides appropriate methods for waiting for events that happen in other threads
(here callback threads).
* Rather than encoding the expectations in fake callbacks, the callbacks are defined as
mock methods and the expectations are set in the tests.