### PR TITLE
Fix handling of empty sequence in capabilities

### DIFF
--- a/pilz_trajectory_generation/CHANGELOG.rst
+++ b/pilz_trajectory_generation/CHANGELOG.rst
@@ -2,6 +2,10 @@
 Changelog for package pilz_trajectory_generation
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+Forthcoming
+-----------
+* change handling of empty sequences in capabilities to be non-erroneous
+
 0.3.2 (2019-01-18)
 ------------------
 * use pilz_testutils package for blend test

--- a/pilz_trajectory_generation/src/command_list_manager.cpp
+++ b/pilz_trajectory_generation/src/command_list_manager.cpp
@@ -67,8 +67,8 @@ bool CommandListManager::solve(const planning_scene::PlanningSceneConstPtr& plan
   if(req_list.items.empty())
   {
     res.trajectory_.reset(new robot_trajectory::RobotTrajectory(model_, 0));
-    res.error_code_.val = moveit_msgs::MoveItErrorCodes::INVALID_MOTION_PLAN;
-    return false;
+    res.error_code_.val = moveit_msgs::MoveItErrorCodes::SUCCESS;
+    return true;
   }
 
   if(!validateRequestList(req_list, res))

--- a/pilz_trajectory_generation/src/move_group_sequence_action.cpp
+++ b/pilz_trajectory_generation/src/move_group_sequence_action.cpp
@@ -71,11 +71,23 @@ void MoveGroupSequenceAction::initialize()
 void MoveGroupSequenceAction::executeSequenceCallback(const pilz_msgs::MoveGroupSequenceGoalConstPtr& goal)
 {
   setMoveState(move_group::PLANNING);
+
+  pilz_msgs::MoveGroupSequenceResult action_res;
+
+  // Handle empty requests
+  if(goal->request.items.empty())
+  {
+    ROS_WARN("Received empty request. That's ok but maybe not what you intended.");
+    setMoveState(move_group::IDLE);
+    action_res.error_code.val = moveit_msgs::MoveItErrorCodes::SUCCESS;
+    move_action_server_->setSucceeded(action_res, "Received empty request.");
+    return;
+  }
+
   // before we start planning, ensure that we have the latest robot state received...
   context_->planning_scene_monitor_->waitForCurrentRobotState(ros::Time::now());
   context_->planning_scene_monitor_->updateFrameTransforms();
 
-  pilz_msgs::MoveGroupSequenceResult action_res;
   if (goal->planning_options.plan_only || !context_->allow_trajectory_execution_)
   {
     if (!goal->planning_options.plan_only)

--- a/pilz_trajectory_generation/test/integrationtest_command_list_manager.cpp
+++ b/pilz_trajectory_generation/test/integrationtest_command_list_manager.cpp
@@ -338,8 +338,8 @@ TEST_P(IntegrationTestCommandListManager, emptyList)
 {
   pilz_msgs::MotionSequenceRequest empty_list;
   planning_interface::MotionPlanResponse res;
-  ASSERT_FALSE(manager_->solve(scene_, empty_list, res));
-  EXPECT_EQ(moveit_msgs::MoveItErrorCodes::INVALID_MOTION_PLAN, res.error_code_.val);
+  ASSERT_TRUE(manager_->solve(scene_, empty_list, res));
+  EXPECT_EQ(moveit_msgs::MoveItErrorCodes::SUCCESS, res.error_code_.val);
   EXPECT_EQ(0u, res.trajectory_->getWayPointCount());
 }
 

--- a/pilz_trajectory_generation/test/integrationtest_sequence_action_capability.cpp
+++ b/pilz_trajectory_generation/test/integrationtest_sequence_action_capability.cpp
@@ -138,7 +138,7 @@ void IntegrationTestSequenceAction::SetUp()
  * Expected Results:
  *    1. Robot moved to start position.
  *    2. Empty blend goal is sent to the action server.
- *    3. Error code of the blend result is INVALIDE_MOTION_PLAN.
+ *    3. Error code of the blend result is SUCCESS.
  */
 TEST_F(IntegrationTestSequenceAction, blendEmptyBlendList)
 {
@@ -147,7 +147,7 @@ TEST_F(IntegrationTestSequenceAction, blendEmptyBlendList)
   // send goal
   ac_blend_.sendGoalAndWait(seq_goal);
   pilz_msgs::MoveGroupSequenceResultConstPtr res = ac_blend_.getResult();
-  EXPECT_EQ(res->error_code.val, moveit_msgs::MoveItErrorCodes::INVALID_MOTION_PLAN);
+  EXPECT_EQ(res->error_code.val, moveit_msgs::MoveItErrorCodes::SUCCESS);
   EXPECT_EQ(res->planned_trajectory.joint_trajectory.points.size(), 0u)
       << "Planned trajectory is not empty of empty motion blend list.";
 }

--- a/pilz_trajectory_generation/test/integrationtest_sequence_service_capability.cpp
+++ b/pilz_trajectory_generation/test/integrationtest_sequence_service_capability.cpp
@@ -230,7 +230,7 @@ TEST_F(IntegrationTestSequenceService, emptyList)
   // Obtain the response
   const moveit_msgs::MotionPlanResponse& response = srv.response.plan_response;
 
-  EXPECT_EQ(moveit_msgs::MoveItErrorCodes::INVALID_MOTION_PLAN, response.error_code.val) << "Planning did failed.";
+  EXPECT_EQ(moveit_msgs::MoveItErrorCodes::SUCCESS, response.error_code.val) << "Planning failed.";
   EXPECT_EQ(0u, response.trajectory.joint_trajectory.points.size()) << "Trajectory should not contain any points.";
 }
 


### PR DESCRIPTION
* Planning + Execution of an empty sequence should be
  defined as successful to avoid errors on clients.
  However a warning indicates to the user that sending
  an empty sequence could have been unintentionally.