### PR TITLE
Ensure valid circ aux point if possible

### DIFF
--- a/pilz_trajectory_generation/CHANGELOG.rst
+++ b/pilz_trajectory_generation/CHANGELOG.rst
@@ -5,6 +5,8 @@ Changelog for package pilz_trajectory_generation
 Forthcoming
 -----------
 * update dependencies of trajectory_generation
+* fix CIRC path generator and increase test coverage
+* Contributors: Pilz GmbH and Co. KG
 
 0.3.6 (2019-02-26)
 ------------------

--- a/pilz_trajectory_generation/README.md
+++ b/pilz_trajectory_generation/README.md
@@ -130,10 +130,11 @@ motion plan fails due to violation of joint space limits.
 
 
 ## The CIRC motion command
-This planner generates an circular arc trajectory in Cartesian space between goal and start poses. The center point of
-the circle or a interim point on the arc needs to be given as path constraint. The planner always generates the shorter
-arc between start and goal poses and cannot generate half circle in case of given center point. The planner cannot generate
-full circle. The Cartesian limits, namely translational/rotational velocity/acceleration/deceleration need to be set
+This planner generates a circular arc trajectory in Cartesian space between goal and start poses. There are two options for giving a path constraint:
+ - the *center* point of the circle: The planner always generates the shorter arc between start and goal and cannot generate a half circle,
+ - an *interim* point on the arc: The generated trajectory always goes through the interim point. The planner cannot generate a full circle.
+
+The Cartesian limits, namely translational/rotational velocity/acceleration/deceleration need to be set
 and the planner uses these limits to generate a trapezoid velocity profile in Cartesian space. The rotational motion is
 quaternion slerp between start and goal orientation. The translational and rotational motion is synchronized in time.
 This planner only accepts start state with zero velocity. Planning result is a joint trajectory. The user needs to adapt

--- a/pilz_trajectory_generation/src/path_circle_generator.cpp
+++ b/pilz_trajectory_generation/src/path_circle_generator.cpp
@@ -84,17 +84,28 @@ std::unique_ptr<KDL::Path> PathCircleGenerator::circleFromInterim(
   const KDL::Vector center_point = start_pose.p + (u*dot(t,t)*dot(u,v) - t*dot(u,u)*dot(t,v))* 0.5/pow(w.Norm(),2);
 
   // compute the rotation angle
-  double interim_angle = cosines(t.Norm(), v.Norm(), u.Norm());
-  double a = (start_pose.p - center_point).Norm();
-  double b = (goal_pose.p - center_point).Norm();
-  double c = (start_pose.p - goal_pose.p).Norm();
-  // compute the rotation angle
+  // triangle edges
+  const KDL::Vector t_center = center_point - start_pose.p;
+  const KDL::Vector v_center = goal_pose.p - center_point;
+  double a = t_center.Norm();
+  double b = v_center.Norm();
+  double c = u.Norm();
   double alpha = cosines(a,b,c);
-  // rotation angle is an acute angle
-  //rotation angle is an obtuse angle
+
+  KDL::Vector kdl_aux_point(interim_point);
+
+  // if the angle at the interim is an acute angle (<90deg), rotation angle is an obtuse angle (>90deg)
+  // in this case using the interim as auxiliary point for KDL::Path_Circle can lead to a path in the wrong direction
+  double interim_angle = cosines(t.Norm(), v.Norm(), u.Norm());
   if(interim_angle < M_PI/2)
   {
     alpha = 2*M_PI - alpha;
+
+    // exclude that the goal is not colinear with start and center, then use the opposite of the goal as auxiliary point
+    if ((t_center*v_center).Norm() > MAX_COLINEAR_NORM)
+    {
+      kdl_aux_point = 2*center_point - goal_pose.p;
+    }
   }
 
   KDL::RotationalInterpolation* rot_interpo = new KDL::RotationalInterpolation_SingleAxis();
@@ -102,7 +113,7 @@ std::unique_ptr<KDL::Path> PathCircleGenerator::circleFromInterim(
   {
     return std::unique_ptr<KDL::Path>(new KDL::Path_Circle(start_pose,
                                                   center_point,
-                                                  interim_point,
+                                                  kdl_aux_point,
                                                   goal_pose.M,
                                                   alpha,
                                                   rot_interpo,

--- a/pilz_trajectory_generation/test/unittest_trajectory_generator_circ.cpp
+++ b/pilz_trajectory_generation/test/unittest_trajectory_generator_circ.cpp
@@ -414,11 +414,14 @@ TEST_P(TrajectoryGeneratorCIRCTest, colinearCenterAndInterim)
 {
   auto circ {tdp_->getCircCartInterimCart("circ3_interim")};
 
-  // swap goal and interim
-  std::swap(circ.getAuxiliaryConfiguration().getConfiguration().getPose().position,
-            circ.getGoalConfiguration().getPose().position);
-  // move goal slightly such that center lies in between start and interim
-  circ.getGoalConfiguration().getPose().position.x += 0.023607;
+  // alter start, interim and goal such that start/center and interim are colinear
+  circ.getAuxiliaryConfiguration().getConfiguration().setPose(circ.getStartConfiguration().getPose());
+  circ.getGoalConfiguration().setPose(circ.getStartConfiguration().getPose());
+
+  circ.getStartConfiguration().getPose().position.x -= 0.2;
+  circ.getAuxiliaryConfiguration().getConfiguration().getPose().position.x += 0.2;
+  circ.getGoalConfiguration().getPose().position.y -= 0.2;
+
   circ.setAccelerationScale(0.05);
   circ.setVelocityScale(0.05);
 

--- a/pilz_trajectory_generation/test/unittest_trajectory_generator_circ.cpp
+++ b/pilz_trajectory_generation/test/unittest_trajectory_generator_circ.cpp
@@ -330,9 +330,9 @@ TEST_P(TrajectoryGeneratorCIRCTest, invalidAuxLinkName)
 }
 
 /**
- * @brief test the circ planner with wrong center point
+ * @brief test the circ planner with invalid center point
  */
-TEST_P(TrajectoryGeneratorCIRCTest, wrongCenter)
+TEST_P(TrajectoryGeneratorCIRCTest, invalidCenter)
 {
   auto circ {tdp_->getCircCartCenterCart("circ1_center_2")};
   circ.getAuxiliaryConfiguration().getConfiguration().setPose(circ.getStartConfiguration().getPose());
@@ -345,6 +345,8 @@ TEST_P(TrajectoryGeneratorCIRCTest, wrongCenter)
 
 /**
  * @brief test the circ planner with colinear start/goal/center position
+ *
+ * Expected: Planning should fail since the path is not uniquely defined.
  */
 TEST_P(TrajectoryGeneratorCIRCTest, colinearCenter)
 {
@@ -363,6 +365,8 @@ TEST_P(TrajectoryGeneratorCIRCTest, colinearCenter)
 
 /**
  * @brief test the circ planner with  colinear start/goal/interim position
+ *
+ * Expected: Planning should fail. These positions do not even represent a circle.
  */
 TEST_P(TrajectoryGeneratorCIRCTest, colinearInterim)
 {
@@ -382,7 +386,7 @@ TEST_P(TrajectoryGeneratorCIRCTest, colinearInterim)
 /**
  * @brief test the circ planner with half circle with interim point
  *
- * The request contains start/interim/goal so that
+ * The request contains start/interim/goal such that
  * start, center (not explicitly given) and goal are colinear
  *
  * Expected: Planning should successfully return.
@@ -395,6 +399,66 @@ TEST_P(TrajectoryGeneratorCIRCTest, colinearCenterDueToInterim)
   planning_interface::MotionPlanResponse res;
   ASSERT_TRUE(circ_->generate(circ.toRequest(),res));
   EXPECT_EQ(res.error_code_.val, moveit_msgs::MoveItErrorCodes::SUCCESS);
+}
+
+/**
+ * @brief test the circ planner with colinear start/center/interim positions
+ *
+ * The request contains start/interim/goal such that
+ * start, center (not explicitly given) and interim are colinear.
+ * In case the interim is used as auxiliary point for KDL::Path_Circle this should fail.
+ *
+ * Expected: Planning should successfully return.
+ */
+TEST_P(TrajectoryGeneratorCIRCTest, colinearCenterAndInterim)
+{
+  auto circ {tdp_->getCircCartInterimCart("circ3_interim")};
+
+  // swap goal and interim
+  std::swap(circ.getAuxiliaryConfiguration().getConfiguration().getPose().position,
+            circ.getGoalConfiguration().getPose().position);
+  // move goal slightly such that center lies in between start and interim
+  circ.getGoalConfiguration().getPose().position.x += 0.023607;
+  circ.setAccelerationScale(0.05);
+  circ.setVelocityScale(0.05);
+
+  moveit_msgs::MotionPlanRequest req = circ.toRequest();
+
+  planning_interface::MotionPlanResponse res;
+  EXPECT_TRUE(circ_->generate(req,res));
+  EXPECT_EQ(res.error_code_.val, moveit_msgs::MoveItErrorCodes::SUCCESS);
+  checkCircResult(req, res);
+}
+
+/**
+ * @brief test the circ planner with a circ path where the angle between goal and interim is larger than 180 degree
+ *
+ * The request contains start/interim/goal such that 180 degree < interim angle < goal angle.
+ *
+ * Expected: Planning should successfully return.
+ */
+TEST_P(TrajectoryGeneratorCIRCTest, interimLarger180Degree)
+{
+  auto circ {tdp_->getCircCartInterimCart("circ3_interim")};
+
+  // alter start, interim and goal such that start/center and interim are colinear
+  circ.getAuxiliaryConfiguration().getConfiguration().setPose(circ.getStartConfiguration().getPose());
+  circ.getGoalConfiguration().setPose(circ.getStartConfiguration().getPose());
+
+  circ.getStartConfiguration().getPose().position.x -= 0.2;
+  circ.getAuxiliaryConfiguration().getConfiguration().getPose().position.x += 0.14142136;
+  circ.getAuxiliaryConfiguration().getConfiguration().getPose().position.y -= 0.14142136;
+  circ.getGoalConfiguration().getPose().position.y -= 0.2;
+
+  circ.setAccelerationScale(0.05);
+  circ.setVelocityScale(0.05);
+
+  moveit_msgs::MotionPlanRequest req = circ.toRequest();
+
+  planning_interface::MotionPlanResponse res;
+  EXPECT_TRUE(circ_->generate(req,res));
+  EXPECT_EQ(res.error_code_.val, moveit_msgs::MoveItErrorCodes::SUCCESS);
+  checkCircResult(req, res);
 }
 
 /**


### PR DESCRIPTION
KDL::Path_Circle computes a plane from start, center and auxiliary point.
So the interim point is not suited, if start, center and interim are colinear.

- [x] check that using goal as aux point is valid
- [x] implement test reproducing this issue