### PR TITLE
using getSingleDOFJointModels instead of  getActiveJointModels to support mimic joints

### DIFF
--- a/pilz_trajectory_generation/src/command_list_manager.cpp
+++ b/pilz_trajectory_generation/src/command_list_manager.cpp
@@ -40,7 +40,7 @@ CommandListManager::CommandListManager(const ros::NodeHandle &nh, const moveit::
   pilz::JointLimitsContainer aggregated_limit_active_joints;
 
   aggregated_limit_active_joints = pilz::JointLimitsAggregator::getAggregatedLimits(
-          ros::NodeHandle(PARAM_NAMESPACE_LIMTS),model_->getActiveJointModels());
+          ros::NodeHandle(PARAM_NAMESPACE_LIMTS),model_->getSingleDOFJointModels());
 
 
   // Obtain cartesian limits

--- a/pilz_trajectory_generation/src/pilz_command_planner.cpp
+++ b/pilz_trajectory_generation/src/pilz_command_planner.cpp
@@ -46,7 +46,7 @@ bool CommandPlanner::initialize(const moveit::core::RobotModelConstPtr &model, c
 
   // Obtain the aggregated joint limits
   aggregated_limit_active_joints_ = pilz::JointLimitsAggregator::getAggregatedLimits(
-        ros::NodeHandle(PARAM_NAMESPACE_LIMTS),model->getActiveJointModels());
+        ros::NodeHandle(PARAM_NAMESPACE_LIMTS),model->getSingleDOFJointModels());
 
   // Obtain cartesian limits
   cartesian_limit_ = pilz::CartesianLimitsAggregator::getAggregatedLimits(ros::NodeHandle(PARAM_NAMESPACE_LIMTS));


### PR DESCRIPTION
Using getSingleDOFJointModels instead of  getActiveJointModels to support mimic joints. Without this change the planner crashes when looking for the joint limits of the mimic joints.