### PR TITLE
Remove genmsg from 'pilz_msgs' package: it's not needed

### DIFF
--- a/pilz_msgs/CMakeLists.txt
+++ b/pilz_msgs/CMakeLists.txt
@@ -2,7 +2,6 @@ cmake_minimum_required(VERSION 2.8.3)
 project(pilz_msgs)
 
 find_package(catkin REQUIRED COMPONENTS
-    genmsg
     message_generation
     moveit_msgs)
 

--- a/pilz_msgs/package.xml
+++ b/pilz_msgs/package.xml
@@ -16,7 +16,6 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
-  <build_depend>genmsg</build_depend>
   <build_depend>message_generation</build_depend>
   <build_depend>moveit_msgs</build_depend>
 


### PR DESCRIPTION
The `genmsg` package is not needed as a dependency of `*_msgs` packages. `message_runtime` and `message_generation` are responsible for pulling in the necessary dependencies.
