### PR TITLE
Fix/Refactor: TrajectoryGeneratorPTP, JointLimitsContainer

### DIFF
--- a/pilz_trajectory_generation/README.md
+++ b/pilz_trajectory_generation/README.md
@@ -60,7 +60,7 @@ the motion request.
 This planner generates full synchronized point to point trajectories with trapezoid joint velocity profile. All joints
 are assumed to have the same maximal joint velocity/acceleration/deceleration limits. If not, the strictest limits are
 adopted. The axis with the longest time to reach the goal is selected as the lead axis.
-Other axes are accelerated so that they share the same acceleration/constant velocity/deceleration phases
+Other axes are decelerated so that they share the same acceleration/constant velocity/deceleration phases
 as the lead axis.
 
 ![ptp no vel](doc/figure/ptp.png)

--- a/pilz_trajectory_generation/include/pilz_trajectory_generation/joint_limits_container.h
+++ b/pilz_trajectory_generation/include/pilz_trajectory_generation/joint_limits_container.h
@@ -133,8 +133,8 @@ private:
    * @param joint_limit
    * @param common_limit the current most strict limit
    */
-  void updateCommonLimit(const pilz_extensions::JointLimit& joint_limit,
-                         pilz_extensions::JointLimit& common_limit) const;
+  static void updateCommonLimit(const pilz_extensions::JointLimit& joint_limit,
+                                pilz_extensions::JointLimit& common_limit);
 
 protected:
   /// Actual container object containing the data

--- a/pilz_trajectory_generation/include/pilz_trajectory_generation/joint_limits_container.h
+++ b/pilz_trajectory_generation/include/pilz_trajectory_generation/joint_limits_container.h
@@ -60,18 +60,30 @@ public:
   bool empty() const;
 
   /**
-   * @brief Returns joint limit fusion of all(position, velocity, acceleration, deceleration) limits
-   * There are cases where the common limits of all is needed. This function calculate and return a joint_limit
-   * which respects all limits of the container.
-   * @return fused joint_limit
-   * if there are no limits, the flag has_[position|velocity|...]_limits is set to false.
+   * @brief Returns joint limit fusion of all(position, velocity, acceleration, deceleration) limits for all joint.
+   * There are cases where the most strict limit of all limits is needed.
+   * If there are no matching limits, the flag has_[position|velocity|...]_limits is set to false.
+   *
+   * @return joint limit
    */
   pilz_extensions::JointLimit getCommonLimit() const;
 
   /**
-   * @brief getLimit get the limit with the name,
+   * @brief Returns joint limit fusion of all(position, velocity, acceleration, deceleration) limits for given joints.
+   * There are cases where the most strict limit of all limits is needed.
+   * If there are no matching limits, the flag has_[position|velocity|...]_limits is set to false.
+   *
+   * @param joint_names
+   * @return joint limit
+   * @throws std::out_of_range if a joint limit with this name does not exist
+   */
+  pilz_extensions::JointLimit getCommonLimit(const std::vector<std::string> &joint_names) const;
+
+  /**
+   * @brief getLimit get the limit for the given joint name
    * @param joint_name
-   * @return joint_limit, throws std::out_of_range if a joint limit with this name does not exist
+   * @return joint limit
+   * @throws std::out_of_range if a joint limit with this name does not exist
    */
   pilz_extensions::JointLimit getLimit(const std::string& joint_name) const;
 
@@ -114,6 +126,15 @@ public:
    */
   bool verifyPositionLimits(const std::vector<std::string> &joint_names,
                             const std::vector<double> &joint_positions) const;
+
+private:
+  /**
+   * @brief update the most strict limit with given joint limit
+   * @param joint_limit
+   * @param common_limit the current most strict limit
+   */
+  void updateCommonLimit(const pilz_extensions::JointLimit& joint_limit,
+                         pilz_extensions::JointLimit& common_limit) const;
 
 protected:
   /// Actual container object containing the data

--- a/pilz_trajectory_generation/include/pilz_trajectory_generation/trajectory_generator_ptp.h
+++ b/pilz_trajectory_generation/include/pilz_trajectory_generation/trajectory_generator_ptp.h
@@ -91,6 +91,7 @@ private:
    * @param start_pos
    * @param goal_pos
    * @param joint_trajectory
+   * @param group_name
    * @param velocity_scaling_factor
    * @param acceleration_scaling_factor
    * @param sampling_time
@@ -98,15 +99,16 @@ private:
   void planPTP(const std::map<std::string, double>& start_pos,
                const std::map<std::string, double>& goal_pos,
                trajectory_msgs::JointTrajectory& joint_trajectory,
+               const std::string &group_name,
                const double& velocity_scaling_factor,
                const double& acceleration_scaling_factor,
                const double& sampling_time);
 
 private:
   const double MIN_MOVEMENT = 0.001;
-  /// ptp planner assume all joints have the same limit
   pilz::JointLimitsContainer joint_limits_;
-  pilz_extensions::JointLimit mostStrictLimit_;
+  // most strict joint limits for each group
+  std::map<std::string, pilz_extensions::JointLimit> most_strict_limits_;
 };
 
 }

--- a/pilz_trajectory_generation/src/joint_limits_container.cpp
+++ b/pilz_trajectory_generation/src/joint_limits_container.cpp
@@ -20,141 +20,75 @@
 #include "ros/ros.h"
 #include <stdexcept>
 
-bool pilz::JointLimitsContainer::addLimit(const std::string &joint_name, pilz_extensions::JointLimit joint_limit)
+namespace pilz
+{
+
+bool JointLimitsContainer::addLimit(const std::string &joint_name, pilz_extensions::JointLimit joint_limit)
 {
   if(joint_limit.has_deceleration_limits && joint_limit.max_deceleration >= 0)
   {
     ROS_ERROR_STREAM("joint_limit.max_deceleration MUST be negative!");
     return false;
   }
-  else
+  if (!container_.insert(std::pair<std::string, pilz_extensions::JointLimit>(joint_name, joint_limit)).second)
   {
-    container_.insert(std::pair<std::string, pilz_extensions::JointLimit>(joint_name, joint_limit));
-    return true;
+    ROS_ERROR_STREAM("joint_limit for joint " << joint_name << " already contained.");
+    return false;
   }
-
+  return true;
 }
 
-bool pilz::JointLimitsContainer::hasLimit(const std::string &joint_name) const
+bool JointLimitsContainer::hasLimit(const std::string &joint_name) const
 {
   return container_.find(joint_name) != container_.end();
 }
 
-size_t pilz::JointLimitsContainer::getCount() const
+size_t JointLimitsContainer::getCount() const
 {
   return container_.size();
 }
 
-bool pilz::JointLimitsContainer::empty() const
+bool JointLimitsContainer::empty() const
 {
   return container_.empty();
 }
 
-pilz_extensions::JointLimit pilz::JointLimitsContainer::getCommonLimit() const
+pilz_extensions::JointLimit JointLimitsContainer::getCommonLimit() const
 {
   pilz_extensions::JointLimit common_limit;
-
-  if(container_.empty())
+  for(auto it = container_.begin(); it != container_.end(); ++it)
   {
-    common_limit.has_position_limits = false;
-    common_limit.min_position = 0;
-    common_limit.max_position = 0;
-    common_limit.has_velocity_limits = false;
-    common_limit.max_velocity = 0;
-    common_limit.has_acceleration_limits = false;
-    common_limit.max_acceleration = 0;
-    common_limit.has_deceleration_limits = false;
-    common_limit.max_deceleration = 0;
-    return common_limit;
+    updateCommonLimit(it->second, common_limit);
   }
-
-  common_limit = container_.begin()->second;
-
-  for(auto it = std::next(container_.begin()); it != container_.end(); ++it)
-  {
-
-    // If this limit has position limits
-    if(it->second.has_position_limits)
-    {
-      // Merge if common_limit has allready limit
-      if(common_limit.has_position_limits)
-      {
-        common_limit.min_position = std::max(common_limit.min_position, it->second.min_position);
-        common_limit.max_position = std::min(common_limit.max_position, it->second.max_position);
-      }
-      else
-      {
-        common_limit.has_position_limits = true;
-        common_limit.min_position = it->second.min_position;
-        common_limit.max_position = it->second.max_position;
-      }
-    }
-
-    // If this limit has velocity limits
-    if(it->second.has_velocity_limits)
-    {
-      // Merge if common_limit has allready limit
-      if(common_limit.has_velocity_limits)
-      {
-        common_limit.max_velocity = std::min(common_limit.max_velocity, it->second.max_velocity);
-      }
-      else
-      {
-        common_limit.has_velocity_limits = true;
-        common_limit.max_velocity = it->second.max_velocity;
-      }
-    }
-
-    // If this limit has acceleration limits
-    if(it->second.has_acceleration_limits)
-    {
-      // Merge if common_limit has allready limit
-      if(common_limit.has_acceleration_limits)
-      {
-        common_limit.max_acceleration = std::min(common_limit.max_acceleration, it->second.max_acceleration);
-      }
-      else
-      {
-        common_limit.has_acceleration_limits = true;
-        common_limit.max_acceleration = it->second.max_acceleration;
-      }
-    }
-
-    // If this limit has deceleration limits
-    if(it->second.has_deceleration_limits)
-    {
-      // Merge if common_limit has allready limit
-      if(common_limit.has_deceleration_limits)
-      {
-        common_limit.max_deceleration = std::max(common_limit.max_deceleration, it->second.max_deceleration);
-      }
-      else
-      {
-        common_limit.has_deceleration_limits = true;
-        common_limit.max_deceleration = it->second.max_deceleration;
-      }
-    }
-  }
-
   return common_limit;
 }
 
-pilz_extensions::JointLimit pilz::JointLimitsContainer::getLimit(const std::string &joint_name) const
+pilz_extensions::JointLimit JointLimitsContainer::getCommonLimit(const std::vector<std::string> &joint_names) const
+{
+  pilz_extensions::JointLimit common_limit;
+  for(auto joint_name : joint_names)
+  {
+    updateCommonLimit(container_.at(joint_name), common_limit);
+  }
+  return common_limit;
+}
+
+pilz_extensions::JointLimit JointLimitsContainer::getLimit(const std::string &joint_name) const
 {
   return container_.at(joint_name);
 }
 
-std::map<std::string, pilz_extensions::JointLimit>::const_iterator pilz::JointLimitsContainer::begin() const
+std::map<std::string, pilz_extensions::JointLimit>::const_iterator JointLimitsContainer::begin() const
 {
   return container_.begin();
 }
 
-std::map<std::string, pilz_extensions::JointLimit>::const_iterator pilz::JointLimitsContainer::end() const
+std::map<std::string, pilz_extensions::JointLimit>::const_iterator JointLimitsContainer::end() const
 {
   return container_.end();
 }
 
-bool pilz::JointLimitsContainer::verifyVelocityLimit(const std::string &joint_name,
+bool JointLimitsContainer::verifyVelocityLimit(const std::string &joint_name,
                                                      const double &joint_velocity) const
 {
   return (!(hasLimit(joint_name)
@@ -163,7 +97,7 @@ bool pilz::JointLimitsContainer::verifyVelocityLimit(const std::string &joint_na
 }
 
 
-bool pilz::JointLimitsContainer::verifyPositionLimit(const std::string &joint_name,
+bool JointLimitsContainer::verifyPositionLimit(const std::string &joint_name,
                                                      const double &joint_position) const
 {
   return (!( hasLimit(joint_name)
@@ -173,7 +107,7 @@ bool pilz::JointLimitsContainer::verifyPositionLimit(const std::string &joint_na
 }
 
 
-bool pilz::JointLimitsContainer::verifyPositionLimits(const std::vector<std::string> &joint_names,
+bool JointLimitsContainer::verifyPositionLimits(const std::vector<std::string> &joint_names,
                                                     const std::vector<double> &joint_positions) const
 {
   if(joint_names.size() != joint_positions.size())
@@ -191,3 +125,51 @@ bool pilz::JointLimitsContainer::verifyPositionLimits(const std::vector<std::str
 
   return true;
 }
+
+void JointLimitsContainer::updateCommonLimit(const pilz_extensions::JointLimit& joint_limit,
+                                                   pilz_extensions::JointLimit& common_limit) const
+{
+  // check position limits
+  if(joint_limit.has_position_limits)
+  {
+    double min_position = joint_limit.min_position;
+    double max_position = joint_limit.max_position;
+
+    common_limit.min_position = (!common_limit.has_position_limits) ? min_position
+                                                                    : std::max(common_limit.min_position, min_position);
+    common_limit.max_position = (!common_limit.has_position_limits) ? max_position
+                                                                    : std::min(common_limit.max_position, max_position);
+    common_limit.has_position_limits = true;
+  }
+
+  // check velocity limits
+  if(joint_limit.has_velocity_limits)
+  {
+    double max_velocity = joint_limit.max_velocity;
+    common_limit.max_velocity = (!common_limit.has_velocity_limits) ? max_velocity
+                                                                    : std::min(common_limit.max_velocity, max_velocity);
+    common_limit.has_velocity_limits = true;
+  }
+
+  // check acceleration limits
+  if(joint_limit.has_acceleration_limits)
+  {
+    double max_acc = joint_limit.max_acceleration;
+    common_limit.max_acceleration = (!common_limit.has_acceleration_limits) ? max_acc
+                                                                            : std::min(common_limit.max_acceleration,
+                                                                                       max_acc);
+    common_limit.has_acceleration_limits = true;
+  }
+
+  // check deceleration limits
+  if(joint_limit.has_deceleration_limits)
+  {
+    double max_dec = joint_limit.max_deceleration;
+    common_limit.max_deceleration = (!common_limit.has_deceleration_limits) ? max_dec
+                                                                            : std::max(common_limit.max_deceleration,
+                                                                                       max_dec);
+    common_limit.has_deceleration_limits = true;
+  }
+}
+
+}  // namespace pilz

--- a/pilz_trajectory_generation/src/joint_limits_container.cpp
+++ b/pilz_trajectory_generation/src/joint_limits_container.cpp
@@ -30,7 +30,9 @@ bool JointLimitsContainer::addLimit(const std::string &joint_name, pilz_extensio
     ROS_ERROR_STREAM("joint_limit.max_deceleration MUST be negative!");
     return false;
   }
-  if (!container_.insert(std::pair<std::string, pilz_extensions::JointLimit>(joint_name, joint_limit)).second)
+  const auto& insertion_result { container_.insert(std::pair<std::string, pilz_extensions::JointLimit>(joint_name,
+                                                                                                       joint_limit)) };
+  if (!insertion_result.second)
   {
     ROS_ERROR_STREAM("joint_limit for joint " << joint_name << " already contained.");
     return false;
@@ -66,7 +68,7 @@ pilz_extensions::JointLimit JointLimitsContainer::getCommonLimit() const
 pilz_extensions::JointLimit JointLimitsContainer::getCommonLimit(const std::vector<std::string> &joint_names) const
 {
   pilz_extensions::JointLimit common_limit;
-  for(auto joint_name : joint_names)
+  for(const auto& joint_name : joint_names)
   {
     updateCommonLimit(container_.at(joint_name), common_limit);
   }
@@ -127,7 +129,7 @@ bool JointLimitsContainer::verifyPositionLimits(const std::vector<std::string> &
 }
 
 void JointLimitsContainer::updateCommonLimit(const pilz_extensions::JointLimit& joint_limit,
-                                                   pilz_extensions::JointLimit& common_limit) const
+                                                   pilz_extensions::JointLimit& common_limit)
 {
   // check position limits
   if(joint_limit.has_position_limits)

--- a/pilz_trajectory_generation/src/trajectory_generator_ptp.cpp
+++ b/pilz_trajectory_generation/src/trajectory_generator_ptp.cpp
@@ -38,7 +38,7 @@ TrajectoryGeneratorPTP::TrajectoryGeneratorPTP(const robot_model::RobotModelCons
   joint_limits_ = planner_limits_.getJointLimitContainer();
 
   // collect most strict joint limits for each group in robot model
-  for(auto jmg : robot_model->getJointModelGroups())
+  for(const auto& jmg : robot_model->getJointModelGroups())
   {
     pilz_extensions::JointLimit most_strict_limit = joint_limits_.getCommonLimit(jmg->getActiveJointModelNames());
 
@@ -197,7 +197,7 @@ void TrajectoryGeneratorPTP::planPTP(const std::map<std::string, double>& start_
         std::stringstream error_str;
         error_str << "TrajectoryGeneratorPTP::planPTP(): Can not synchronize velocity profile of axis " << joint_name
                << " with leading axis " << leading_axis;
-        std::runtime_error(error_str.str());
+        throw TrajectoryGeneratorException(error_str.str());
       }
       // LCOV_EXCL_STOP
     }

--- a/pilz_trajectory_generation/src/trajectory_generator_ptp.cpp
+++ b/pilz_trajectory_generation/src/trajectory_generator_ptp.cpp
@@ -192,12 +192,14 @@ void TrajectoryGeneratorPTP::planPTP(const std::map<std::string, double>& start_
       // by using the most strict limit, the following should always return true
       if (!velocity_profile.at(joint_name).SetProfileAllDurations(start_pos.at(joint_name), goal_pos.at(joint_name),
                                                                   acc_time,const_time,dec_time))
+      // LCOV_EXCL_START
       {
         std::stringstream error_str;
         error_str << "TrajectoryGeneratorPTP::planPTP(): Can not synchronize velocity profile of axis " << joint_name
                << " with leading axis " << leading_axis;
         std::runtime_error(error_str.str());
       }
+      // LCOV_EXCL_STOP
     }
   }
 

--- a/pilz_trajectory_generation/src/trajectory_generator_ptp.cpp
+++ b/pilz_trajectory_generation/src/trajectory_generator_ptp.cpp
@@ -21,6 +21,7 @@
 #include "moveit/robot_state/conversions.h"
 
 #include <iostream>
+#include <sstream>
 
 namespace pilz {
 
@@ -35,37 +36,32 @@ TrajectoryGeneratorPTP::TrajectoryGeneratorPTP(const robot_model::RobotModelCons
   }
 
   joint_limits_ = planner_limits_.getJointLimitContainer();
-  mostStrictLimit_ = joint_limits_.getCommonLimit();
 
-  if(mostStrictLimit_.has_velocity_limits &&
-     mostStrictLimit_.has_acceleration_limits &&
-     mostStrictLimit_.has_deceleration_limits)
+  // collect most strict joint limits for each group in robot model
+  for(auto jmg : robot_model->getJointModelGroups())
   {
-    ROS_INFO("Initialized Point-to-Point Trajectory Generator.");
-    ROS_DEBUG_STREAM("CommontLimit: " << "\n\t PositionLimits[" << mostStrictLimit_.min_position
-                     << " ," << mostStrictLimit_.max_position << "]"
-                     << "\n\t MaxVelocity " << mostStrictLimit_.max_velocity
-                     << "\n\t MaxAcceleration" << mostStrictLimit_.max_acceleration
-                     << "\n\t MaxDeceleration " << mostStrictLimit_.max_deceleration);
+    pilz_extensions::JointLimit most_strict_limit = joint_limits_.getCommonLimit(jmg->getActiveJointModelNames());
+
+    if(!most_strict_limit.has_velocity_limits)
+    {
+      ROS_ERROR_STREAM("velocity limit not set for group " << jmg->getName());
+      throw TrajectoryGeneratorInvalidLimitsException("velocity limit not set for group " + jmg->getName());
+    }
+    if(!most_strict_limit.has_acceleration_limits)
+    {
+      ROS_ERROR_STREAM("acceleration limit not set for group " << jmg->getName());
+      throw TrajectoryGeneratorInvalidLimitsException("acceleration limit not set for group " + jmg->getName());
+    }
+    if(!most_strict_limit.has_deceleration_limits)
+    {
+      ROS_ERROR_STREAM("deceleration limit not set for group " << jmg->getName());
+      throw TrajectoryGeneratorInvalidLimitsException("deceleration limit not set for group " + jmg->getName());
+    }
+
+    most_strict_limits_.insert(std::pair<std::string, pilz_extensions::JointLimit>(jmg->getName(), most_strict_limit));
   }
-  else
-  {
-    if(!mostStrictLimit_.has_velocity_limits)
-    {
-      ROS_ERROR("velocity limit not set");
-      throw TrajectoryGeneratorInvalidLimitsException("velocity limit not set");
-    }
-    if(!mostStrictLimit_.has_acceleration_limits)
-    {
-      ROS_ERROR("acceleration limit not set");
-      throw TrajectoryGeneratorInvalidLimitsException("acceleration limit not set");
-    }
-    if(!mostStrictLimit_.has_deceleration_limits)
-    {
-      ROS_ERROR("deceleration limit not set");
-      throw TrajectoryGeneratorInvalidLimitsException("deceleartion limit not set");
-    }
-  }
+
+  ROS_INFO("Initialized Point-to-Point Trajectory Generator.");
 }
 
 TrajectoryGeneratorPTP::~TrajectoryGeneratorPTP()
@@ -103,7 +99,7 @@ bool TrajectoryGeneratorPTP::generate(const planning_interface::MotionPlanReques
 
   // plan the ptp trajectory
   trajectory_msgs::JointTrajectory joint_trajectory;
-  planPTP(plan_info.start_joint_position, plan_info.goal_joint_position, joint_trajectory,
+  planPTP(plan_info.start_joint_position, plan_info.goal_joint_position, joint_trajectory, plan_info.group_name,
           req.max_velocity_scaling_factor, req.max_acceleration_scaling_factor, sampling_time);
 
   ROS_INFO_STREAM("PTP Trajectory with " << joint_trajectory.points.size() << " Points generated. Took "
@@ -118,6 +114,7 @@ bool TrajectoryGeneratorPTP::generate(const planning_interface::MotionPlanReques
 void TrajectoryGeneratorPTP::planPTP(const std::map<std::string, double>& start_pos,
                                      const std::map<std::string, double>& goal_pos,
                                      trajectory_msgs::JointTrajectory &joint_trajectory,
+                                     const std::string &group_name,
                                      const double &velocity_scaling_factor,
                                      const double &acceleration_scaling_factor,
                                      const double &sampling_time)
@@ -163,14 +160,13 @@ void TrajectoryGeneratorPTP::planPTP(const std::map<std::string, double>& start_
   std::map<std::string, VelocityProfile_ATrap> velocity_profile;
   for(const auto& joint_name : joint_trajectory.joint_names)
   {
-
     // create vecocity profile if necessary
     velocity_profile.insert(std::make_pair(
                               joint_name,
                               VelocityProfile_ATrap(
-                                velocity_scaling_factor*joint_limits_.getLimit(joint_name).max_velocity,
-                                acceleration_scaling_factor*joint_limits_.getLimit(joint_name).max_acceleration,
-                                acceleration_scaling_factor*joint_limits_.getLimit(joint_name).max_deceleration)));
+                                velocity_scaling_factor * most_strict_limits_.at(group_name).max_velocity,
+                                acceleration_scaling_factor * most_strict_limits_.at(group_name).max_acceleration,
+                                acceleration_scaling_factor * most_strict_limits_.at(group_name).max_deceleration)));
 
     velocity_profile.at(joint_name).SetProfile(start_pos.at(joint_name), goal_pos.at(joint_name));
     if(velocity_profile.at(joint_name).Duration() > max_duration)
@@ -180,16 +176,8 @@ void TrajectoryGeneratorPTP::planPTP(const std::map<std::string, double>& start_
     }
   }
 
-  // TODO throw exception?
-  if(max_duration<=0)
-  {
-    ROS_ERROR("Trajectory duration is zero. It should not happen here.");
-    joint_trajectory.points.clear();
-    return;
-  }
-
   // Full Synchronization
-  // TODO!!! we assume all axes have same max_vel, max_acc, max_dec values
+  // This should only work if all axes have same max_vel, max_acc, max_dec values
   // reset the velocity profile for other joints
   double acc_time = velocity_profile.at(leading_axis).FirstPhaseDuration();
   double const_time = velocity_profile.at(leading_axis).SecondPhaseDuration();
@@ -200,8 +188,16 @@ void TrajectoryGeneratorPTP::planPTP(const std::map<std::string, double>& start_
     if(joint_name != leading_axis)
     {
       // make full synchronization
-      velocity_profile.at(joint_name).SetProfileAllDurations(start_pos.at(joint_name), goal_pos.at(joint_name),
-                                                             acc_time,const_time,dec_time);
+      // causes the program to terminate if acc_time<=0 or dec_time<=0 (should be prevented by goal_reached block above)
+      // by using the most strict limit, the following should always return true
+      if (!velocity_profile.at(joint_name).SetProfileAllDurations(start_pos.at(joint_name), goal_pos.at(joint_name),
+                                                                  acc_time,const_time,dec_time))
+      {
+        std::stringstream error_str;
+        error_str << "TrajectoryGeneratorPTP::planPTP(): Can not synchronize velocity profile of axis " << joint_name
+               << " with leading axis " << leading_axis;
+        std::runtime_error(error_str.str());
+      }
     }
   }
 

--- a/pilz_trajectory_generation/test/integrationtest_command_list_manager.test
+++ b/pilz_trajectory_generation/test/integrationtest_command_list_manager.test
@@ -19,8 +19,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
   <!-- Parametrized test running with and without gripper! -->
 
   <!-- Load the context with and without the pg70 -->
-  <include file="$(find prbt_moveit_config)/launch/test_context.launch" />
-  <include file="$(find prbt_moveit_config)/launch/test_context.launch">
+  <include file="$(find pilz_trajectory_generation)/test/test_robots/prbt/launch/test_context.launch" />
+  <include file="$(find pilz_trajectory_generation)/test/test_robots/prbt/launch/test_context.launch">
     <arg name="gripper" value="pg70" />
   </include>
 

--- a/pilz_trajectory_generation/test/test_robots/frankaemika_panda/config/joint_limits.yaml
+++ b/pilz_trajectory_generation/test/test_robots/frankaemika_panda/config/joint_limits.yaml
@@ -1,0 +1,24 @@
+#
+# Copyright (c) 2018 Pilz GmbH & Co. KG
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+# define acceleration limits for panda finger joints for compability with the PTP planner
+joint_limits:
+  panda_finger_joint1:
+    has_acceleration_limits: true
+    max_acceleration: 1.0
+  panda_finger_joint2:
+    has_acceleration_limits: true
+    max_acceleration: 1.0

--- a/pilz_trajectory_generation/test/test_robots/frankaemika_panda/launch/move_group.launch
+++ b/pilz_trajectory_generation/test/test_robots/frankaemika_panda/launch/move_group.launch
@@ -13,6 +13,11 @@
     <arg name="load_gripper" value="$(arg load_gripper)" />
   </include>
 
+  <!-- Load additional joint limits for compability with the PTP planner -->
+  <group ns="robot_description_planning">
+    <rosparam command="load" file="$(find pilz_trajectory_generation)/test/test_robots/frankaemika_panda/config/joint_limits.yaml"/>
+  </group>
+
   <!-- GDB Debug Option -->
   <arg name="debug" default="false" />
   <arg unless="$(arg debug)" name="launch_prefix" value="" />

--- a/pilz_trajectory_generation/test/test_robots/prbt/launch/test_context.launch
+++ b/pilz_trajectory_generation/test/test_robots/prbt/launch/test_context.launch
@@ -1,0 +1,43 @@
+<launch>
+
+  <!-- Defining a gripper will load all parameters with the defined gripper -->
+  <arg name="gripper" default=""/>
+
+  <!-- URDF and SRDF without gripper -->
+  <!-- The name of the parameter under which the URDF is loaded -->
+  <arg if="$(eval not gripper)" name="robot_description" default="robot_description"/>
+  <arg unless="$(eval not gripper)" name="robot_description" default="robot_description_$(arg gripper)"/>
+
+  <!-- Load universal robot description format (URDF) -->
+  <param name="$(arg robot_description)"
+         command="$(find xacro)/xacro --inorder $(find prbt_support)/urdf/prbt.xacro gripper:=$(arg gripper)"/>
+
+  <!-- The semantic description that corresponds to the URDF -->
+  <param name="$(arg robot_description)_semantic" command="$(find xacro)/xacro --inorder
+         $(find prbt_moveit_config)/config/prbt.srdf.xacro gripper:=$(arg gripper)" />
+
+
+  <!-- Load updated joint limits (override information from URDF) -->
+  <group ns="$(arg robot_description)_planning">
+    <rosparam if="$(eval not gripper)" command="load" file="$(find prbt_moveit_config)/config/joint_limits.yaml"/>
+    <rosparam unless="$(eval not gripper)" command="load"
+              file="$(eval find('prbt_'+ gripper + '_support') + '/config/joint_limits.yaml')" />
+
+    <!-- Load cartesian limits -->
+    <rosparam command="load" file="$(find prbt_moveit_config)/config/cartesian_limits.yaml"/>
+  </group>
+
+  <!-- Load limits again in default namespace (which may not be configurable for planners) -->
+  <group ns="robot_description_planning">
+    <rosparam if="$(eval not gripper)" command="load" file="$(find prbt_moveit_config)/config/joint_limits.yaml"/>
+    <rosparam unless="$(eval not gripper)" command="load"
+              file="$(eval find('prbt_'+ gripper + '_support') + '/config/joint_limits.yaml')" />
+    <rosparam command="load" file="$(find prbt_moveit_config)/config/cartesian_limits.yaml"/>
+  </group>
+
+  <!-- Load default settings for kinematics; these settings are overridden by settings in a node's namespace -->
+  <group ns="$(arg robot_description)_kinematics">
+    <rosparam command="load" file="$(find prbt_moveit_config)/config/kinematics.yaml"/>
+  </group>
+  
+</launch>

--- a/pilz_trajectory_generation/test/test_utils.cpp
+++ b/pilz_trajectory_generation/test/test_utils.cpp
@@ -22,6 +22,29 @@
 #include <moveit/robot_state/conversions.h>
 #include <moveit/planning_interface/planning_interface.h>
 
+pilz::JointLimitsContainer testutils::createFakeLimits(const std::vector<std::string>& joint_names)
+{
+  pilz::JointLimitsContainer container;
+
+  for(const std::string& name : joint_names)
+  {
+    pilz_extensions::JointLimit limit;
+    limit.has_position_limits = true;
+    limit.max_position = 2.967;
+    limit.min_position = -2.967;
+    limit.has_velocity_limits = true;
+    limit.max_velocity = 1;
+    limit.has_acceleration_limits = true;
+    limit.max_acceleration = 0.5;
+    limit.has_deceleration_limits = true;
+    limit.max_deceleration = -1;
+
+    container.addLimit(name, limit);
+  }
+
+  return container;
+}
+
 bool testutils::getExpectedGoalPose(const moveit::core::RobotModelConstPtr &robot_model,
                                     const planning_interface::MotionPlanRequest &req,
                                     std::string &link_name,

--- a/pilz_trajectory_generation/test/test_utils.h
+++ b/pilz_trajectory_generation/test/test_utils.h
@@ -60,16 +60,15 @@ inline std::string getJointName(size_t joint_number, std::string joint_prefix)
 }
 
 /**
-   * @brief Create limits for tests to avoid the need to get the from the parameter server
-   * @param joint_number
+   * @brief Create limits for tests to avoid the need to get the limits from the parameter server
+   * @param robot_model
    * @return
    */
-inline pilz::JointLimitsContainer createFakeLimits(size_t joint_number,
-                                                   std::string joint_prefix = testutils::JOINT_NAME_PREFIX)
+inline pilz::JointLimitsContainer createFakeLimits(robot_model::RobotModelConstPtr &robot_model)
 {
   pilz::JointLimitsContainer container;
 
-  for(size_t i = 0; i < joint_number; ++i)
+  for(std::string name : robot_model->getVariableNames())
   {
     pilz_extensions::JointLimit limit;
     limit.has_position_limits = true;
@@ -82,7 +81,7 @@ inline pilz::JointLimitsContainer createFakeLimits(size_t joint_number,
     limit.has_deceleration_limits = true;
     limit.max_deceleration = -1;
 
-    container.addLimit(getJointName(i+1, joint_prefix), limit);
+    container.addLimit(name, limit);
   }
 
   return container;

--- a/pilz_trajectory_generation/test/test_utils.h
+++ b/pilz_trajectory_generation/test/test_utils.h
@@ -61,31 +61,8 @@ inline std::string getJointName(size_t joint_number, std::string joint_prefix)
 
 /**
    * @brief Create limits for tests to avoid the need to get the limits from the parameter server
-   * @param robot_model
-   * @return
    */
-inline pilz::JointLimitsContainer createFakeLimits(robot_model::RobotModelConstPtr &robot_model)
-{
-  pilz::JointLimitsContainer container;
-
-  for(std::string name : robot_model->getVariableNames())
-  {
-    pilz_extensions::JointLimit limit;
-    limit.has_position_limits = true;
-    limit.max_position = 2.967;
-    limit.min_position = -2.967;
-    limit.has_velocity_limits = true;
-    limit.max_velocity = 1;
-    limit.has_acceleration_limits = true;
-    limit.max_acceleration = 0.5;
-    limit.has_deceleration_limits = true;
-    limit.max_deceleration = -1;
-
-    container.addLimit(name, limit);
-  }
-
-  return container;
-}
+pilz::JointLimitsContainer createFakeLimits(const std::vector<std::string>& joint_names);
 
 
 inline std::string demangel(char const * name)

--- a/pilz_trajectory_generation/test/unittest_joint_limits_container.cpp
+++ b/pilz_trajectory_generation/test/unittest_joint_limits_container.cpp
@@ -122,7 +122,7 @@ TEST_F(JointLimitsContainerTest, CheckDecelerationUnification)
 /**
  * @brief Check AddLimit for positive and null deceleration
  */
-TEST_F(JointLimitsContainerTest, CheckAddLimit)
+TEST_F(JointLimitsContainerTest, CheckAddLimitDeceleration)
 {
 
   pilz_extensions::JointLimit lim_invalid1;
@@ -142,6 +142,20 @@ TEST_F(JointLimitsContainerTest, CheckAddLimit)
   EXPECT_EQ(false, container.addLimit("joint_invalid1", lim_invalid1));
   EXPECT_EQ(false, container.addLimit("joint_invalid2", lim_invalid2));
   EXPECT_EQ(true, container.addLimit("joint_valid", lim_valid));
+}
+
+/**
+ * @brief Check AddLimit for already contained limit
+ */
+TEST_F(JointLimitsContainerTest, CheckAddLimitAlreadyContained)
+{
+  pilz_extensions::JointLimit lim_valid;
+  lim_valid.has_deceleration_limits = true;
+  lim_valid.max_deceleration = -1;
+
+  pilz::JointLimitsContainer container;
+  ASSERT_TRUE(container.addLimit("joint_valid", lim_valid));
+  EXPECT_FALSE(container.addLimit("joint_valid", lim_valid));
 }
 
 /**

--- a/pilz_trajectory_generation/test/unittest_pilz_command_planner.test
+++ b/pilz_trajectory_generation/test/unittest_pilz_command_planner.test
@@ -19,8 +19,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
   <!-- Parametrized test running with and without gripper! -->
 
   <!-- Load the context with and without the pg70 -->
-  <include file="$(find prbt_moveit_config)/launch/test_context.launch" />
-  <include file="$(find prbt_moveit_config)/launch/test_context.launch">
+  <include file="$(find pilz_trajectory_generation)/test/test_robots/prbt/launch/test_context.launch" />
+  <include file="$(find pilz_trajectory_generation)/test/test_robots/prbt/launch/test_context.launch">
     <arg name="gripper" value="pg70" />
   </include>
 

--- a/pilz_trajectory_generation/test/unittest_planning_context.cpp
+++ b/pilz_trajectory_generation/test/unittest_planning_context.cpp
@@ -84,7 +84,7 @@ protected:
     ASSERT_TRUE(ph_.getParam(PARAM_PLANNING_GROUP_NAME, planning_group_));
     ASSERT_TRUE(ph_.getParam(PARAM_TARGET_LINK_NAME, target_link_));
 
-    pilz::JointLimitsContainer joint_limits = testutils::createFakeLimits(6);
+    pilz::JointLimitsContainer joint_limits = testutils::createFakeLimits(robot_model_);
     pilz::CartesianLimit cartesian_limit;
     cartesian_limit.setMaxRotationalVelocity(1.0*M_PI);
     cartesian_limit.setMaxTranslationalAcceleration(1.0*M_PI);

--- a/pilz_trajectory_generation/test/unittest_planning_context.cpp
+++ b/pilz_trajectory_generation/test/unittest_planning_context.cpp
@@ -84,7 +84,7 @@ protected:
     ASSERT_TRUE(ph_.getParam(PARAM_PLANNING_GROUP_NAME, planning_group_));
     ASSERT_TRUE(ph_.getParam(PARAM_TARGET_LINK_NAME, target_link_));
 
-    pilz::JointLimitsContainer joint_limits = testutils::createFakeLimits(robot_model_);
+    pilz::JointLimitsContainer joint_limits = testutils::createFakeLimits(robot_model_->getVariableNames());
     pilz::CartesianLimit cartesian_limit;
     cartesian_limit.setMaxRotationalVelocity(1.0*M_PI);
     cartesian_limit.setMaxTranslationalAcceleration(1.0*M_PI);

--- a/pilz_trajectory_generation/test/unittest_planning_context.test
+++ b/pilz_trajectory_generation/test/unittest_planning_context.test
@@ -17,8 +17,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 <launch>
   <!-- load test parameters-->
-  <include file="$(find prbt_moveit_config)/launch/test_context.launch" />
-  <include file="$(find prbt_moveit_config)/launch/test_context.launch">
+  <include file="$(find pilz_trajectory_generation)/test/test_robots/prbt/launch/test_context.launch" />
+  <include file="$(find pilz_trajectory_generation)/test/test_robots/prbt/launch/test_context.launch">
     <arg name="gripper" value="pg70" />
   </include>
 

--- a/pilz_trajectory_generation/test/unittest_planning_context_loaders.cpp
+++ b/pilz_trajectory_generation/test/unittest_planning_context_loaders.cpp
@@ -120,7 +120,7 @@ TEST_P(PlanningContextLoadersTest, LoadContext)
   EXPECT_EQ(false, res) << "Context returned even when no limits where set";
 
   // After setting the limits this should work
-  pilz::JointLimitsContainer joint_limits = testutils::createFakeLimits(robot_model_);
+  pilz::JointLimitsContainer joint_limits = testutils::createFakeLimits(robot_model_->getVariableNames());
   pilz::LimitsContainer limits;
   limits.setJointLimits(joint_limits);
   pilz::CartesianLimit cart_limits;

--- a/pilz_trajectory_generation/test/unittest_planning_context_loaders.cpp
+++ b/pilz_trajectory_generation/test/unittest_planning_context_loaders.cpp
@@ -120,7 +120,7 @@ TEST_P(PlanningContextLoadersTest, LoadContext)
   EXPECT_EQ(false, res) << "Context returned even when no limits where set";
 
   // After setting the limits this should work
-  pilz::JointLimitsContainer joint_limits = testutils::createFakeLimits(6);
+  pilz::JointLimitsContainer joint_limits = testutils::createFakeLimits(robot_model_);
   pilz::LimitsContainer limits;
   limits.setJointLimits(joint_limits);
   pilz::CartesianLimit cart_limits;

--- a/pilz_trajectory_generation/test/unittest_planning_context_loaders.test
+++ b/pilz_trajectory_generation/test/unittest_planning_context_loaders.test
@@ -19,8 +19,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
   <!-- Parametrized test running with and without gripper! -->
 
   <!-- Load the context with and without the pg70 -->
-  <include file="$(find prbt_moveit_config)/launch/test_context.launch" />
-  <include file="$(find prbt_moveit_config)/launch/test_context.launch">
+  <include file="$(find pilz_trajectory_generation)/test/test_robots/prbt/launch/test_context.launch" />
+  <include file="$(find pilz_trajectory_generation)/test/test_robots/prbt/launch/test_context.launch">
     <arg name="gripper" value="pg70" />
   </include>
 

--- a/pilz_trajectory_generation/test/unittest_trajectory_appender.test
+++ b/pilz_trajectory_generation/test/unittest_trajectory_appender.test
@@ -17,7 +17,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 <launch>
     <!-- Load the context -->
-    <include file="$(find prbt_moveit_config)/launch/test_context.launch" />
+    <include file="$(find pilz_trajectory_generation)/test/test_robots/prbt/launch/test_context.launch" />
 
     <!-- run test -->
     <test pkg="pilz_trajectory_generation" test-name="unittest_trajectory_appender"

--- a/pilz_trajectory_generation/test/unittest_trajectory_blender_transition_window.test
+++ b/pilz_trajectory_generation/test/unittest_trajectory_blender_transition_window.test
@@ -19,8 +19,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
   <!-- Parametrized test running with and without gripper! -->
 
   <!-- Load the context with and without the pg70 -->
-  <include file="$(find prbt_moveit_config)/launch/test_context.launch" />
-  <include file="$(find prbt_moveit_config)/launch/test_context.launch">
+  <include file="$(find pilz_trajectory_generation)/test/test_robots/prbt/launch/test_context.launch" />
+  <include file="$(find pilz_trajectory_generation)/test/test_robots/prbt/launch/test_context.launch">
     <arg name="gripper" value="pg70" />
   </include>
 

--- a/pilz_trajectory_generation/test/unittest_trajectory_functions.test
+++ b/pilz_trajectory_generation/test/unittest_trajectory_functions.test
@@ -19,8 +19,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
   <!-- Parametrized test running with and without gripper! -->
 
   <!-- Load the context with and without the pg70 -->
-  <include file="$(find prbt_moveit_config)/launch/test_context.launch" />
-  <include file="$(find prbt_moveit_config)/launch/test_context.launch">
+  <include file="$(find pilz_trajectory_generation)/test/test_robots/prbt/launch/test_context.launch" />
+  <include file="$(find pilz_trajectory_generation)/test/test_robots/prbt/launch/test_context.launch">
     <arg name="gripper" value="pg70" />
   </include>
 

--- a/pilz_trajectory_generation/test/unittest_trajectory_generator_circ.cpp
+++ b/pilz_trajectory_generation/test/unittest_trajectory_generator_circ.cpp
@@ -261,12 +261,35 @@ TEST_P(TrajectoryGeneratorCIRCTest, accScaleToHigh)
 }
 
 /**
- * @brief Use three points with a really small distance between to trigger a internal throw from KDL
+ * @brief Use three points (with center) with a really small distance between to trigger a internal throw from KDL
  */
-TEST_P(TrajectoryGeneratorCIRCTest, samePoints)
+TEST_P(TrajectoryGeneratorCIRCTest, samePointsWithCenter)
 {
   // Define auxiliary point and goal to be the same as the start
   auto circ {tdp_->getCircCartCenterCart("circ1_center_2")};
+  circ.getAuxiliaryConfiguration().getConfiguration().setPose(circ.getStartConfiguration().getPose());
+  circ.getAuxiliaryConfiguration().getConfiguration().getPose().position.x += 1e-8;
+  circ.getAuxiliaryConfiguration().getConfiguration().getPose().position.y += 1e-8;
+  circ.getAuxiliaryConfiguration().getConfiguration().getPose().position.z += 1e-8;
+  circ.getGoalConfiguration().setPose(circ.getStartConfiguration().getPose());
+  circ.getGoalConfiguration().getPose().position.x -= 1e-8;
+  circ.getGoalConfiguration().getPose().position.y -= 1e-8;
+  circ.getGoalConfiguration().getPose().position.z -= 1e-8;
+
+  planning_interface::MotionPlanResponse res;
+  EXPECT_FALSE(circ_->generate(circ.toRequest(),res));
+  EXPECT_EQ(res.error_code_.val, moveit_msgs::MoveItErrorCodes::INVALID_MOTION_PLAN);
+}
+
+/**
+ * @brief Use three points (with interim) with a really small distance between
+ *
+ * Expected: Planning should fail.
+ */
+TEST_P(TrajectoryGeneratorCIRCTest, samePointsWithInterim)
+{
+  // Define auxiliary point and goal to be the same as the start
+  auto circ {tdp_->getCircCartInterimCart("circ3_interim")};
   circ.getAuxiliaryConfiguration().getConfiguration().setPose(circ.getStartConfiguration().getPose());
   circ.getAuxiliaryConfiguration().getConfiguration().getPose().position.x += 1e-8;
   circ.getAuxiliaryConfiguration().getConfiguration().getPose().position.y += 1e-8;

--- a/pilz_trajectory_generation/test/unittest_trajectory_generator_circ.test
+++ b/pilz_trajectory_generation/test/unittest_trajectory_generator_circ.test
@@ -21,8 +21,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
   <!-- Parametrized test running with and without gripper! -->
 
   <!-- Load the context with and without the pg70 -->
-  <include file="$(find prbt_moveit_config)/launch/test_context.launch" />
-  <include file="$(find prbt_moveit_config)/launch/test_context.launch">
+  <include file="$(find pilz_trajectory_generation)/test/test_robots/prbt/launch/test_context.launch" />
+  <include file="$(find pilz_trajectory_generation)/test/test_robots/prbt/launch/test_context.launch">
     <arg name="gripper" value="pg70" />
   </include>
 

--- a/pilz_trajectory_generation/test/unittest_trajectory_generator_common.cpp
+++ b/pilz_trajectory_generation/test/unittest_trajectory_generator_common.cpp
@@ -89,8 +89,10 @@ protected:
     testutils::checkRobotModel(robot_model_, planning_group_, target_link_);
 
     // create the limits container
+    std::string robot_description_param = (!T::Value_ ? PARAM_MODEL_NO_GRIPPER_NAME: PARAM_MODEL_WITH_GRIPPER_NAME);
     pilz::JointLimitsContainer joint_limits =
-        pilz::JointLimitsAggregator::getAggregatedLimits(ph_, robot_model_->getActiveJointModels());
+        pilz::JointLimitsAggregator::getAggregatedLimits(ros::NodeHandle(robot_description_param + "_planning"),
+                                                         robot_model_->getActiveJointModels());
     pilz::CartesianLimit cart_limits;
     cart_limits.setMaxRotationalVelocity(0.5*M_PI);
     cart_limits.setMaxTranslationalAcceleration(2);

--- a/pilz_trajectory_generation/test/unittest_trajectory_generator_common.test
+++ b/pilz_trajectory_generation/test/unittest_trajectory_generator_common.test
@@ -19,8 +19,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
   <!-- Parametrized test running with and without gripper! -->
 
   <!-- Load the context with and without the pg70 -->
-  <include file="$(find prbt_moveit_config)/launch/test_context.launch" />
-  <include file="$(find prbt_moveit_config)/launch/test_context.launch">
+  <include file="$(find pilz_trajectory_generation)/test/test_robots/prbt/launch/test_context.launch" />
+  <include file="$(find pilz_trajectory_generation)/test/test_robots/prbt/launch/test_context.launch">
     <arg name="gripper" value="pg70" />
   </include>
 
@@ -36,7 +36,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
     <param name="rot_axis_norm_tolerance" value="1.0e-6" />
     <param name="other_tolerance" value="1.0e-6" />
     <param name="velocity_scaling_factor" value="0.1" />
-    <rosparam command="load" file="$(find prbt_moveit_config)/config/joint_limits.yaml" />
   </test>
 
 

--- a/pilz_trajectory_generation/test/unittest_trajectory_generator_lin.test
+++ b/pilz_trajectory_generation/test/unittest_trajectory_generator_lin.test
@@ -21,8 +21,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
   <!-- Parametrized test running with and without gripper! -->
 
   <!-- Load the context with and without the pg70 -->
-  <include file="$(find prbt_moveit_config)/launch/test_context.launch" />
-  <include file="$(find prbt_moveit_config)/launch/test_context.launch">
+  <include file="$(find pilz_trajectory_generation)/test/test_robots/prbt/launch/test_context.launch" />
+  <include file="$(find pilz_trajectory_generation)/test/test_robots/prbt/launch/test_context.launch">
     <arg name="gripper" value="pg70" />
   </include>
 

--- a/pilz_trajectory_generation/test/unittest_trajectory_generator_ptp.cpp
+++ b/pilz_trajectory_generation/test/unittest_trajectory_generator_ptp.cpp
@@ -90,25 +90,24 @@ void TrajectoryGeneratorPTPTest::SetUp()
   testutils::checkRobotModel(robot_model_, planning_group_, target_link_);
 
   // create the limits container
-  //pilz::JointLimitsContainer joint_limits =
-  //    pilz::JointLimitsAggregator::getAggregatedLimits(ph_, robot_model_->getActiveJointModels());
   pilz::JointLimitsContainer joint_limits;
-  std::vector<std::string> joint_names = robot_model_->getJointModelGroup(planning_group_)->getActiveJointModelNames();
-  pilz_extensions::joint_limits_interface::JointLimits joint_limit;
-  joint_limit.max_position = 3.124;
-  joint_limit.min_position = -3.124;
-  joint_limit.has_velocity_limits = true;
-  joint_limit.max_velocity = 1;
-  joint_limit.has_acceleration_limits = true;
-  joint_limit.max_acceleration = 0.5;
-  joint_limit.has_deceleration_limits = true;
-  joint_limit.max_deceleration = -1;
-  for(const auto& joint_name : joint_names)
+  for(auto jmg : robot_model_->getJointModelGroups())
   {
-    joint_limits.addLimit(joint_name, joint_limit);
+    std::vector<std::string> joint_names = jmg->getActiveJointModelNames();
+    pilz_extensions::joint_limits_interface::JointLimits joint_limit;
+    joint_limit.max_position = 3.124;
+    joint_limit.min_position = -3.124;
+    joint_limit.has_velocity_limits = true;
+    joint_limit.max_velocity = 1;
+    joint_limit.has_acceleration_limits = true;
+    joint_limit.max_acceleration = 0.5;
+    joint_limit.has_deceleration_limits = true;
+    joint_limit.max_deceleration = -1;
+    for(const auto& joint_name : joint_names)
+    {
+      joint_limits.addLimit(joint_name, joint_limit);
+    }
   }
-  // create a fake joint limit to influence the common limit
-  joint_limits.addLimit("fake_joint", joint_limit);
 
    // create the trajectory generator
   planner_limits_.setJointLimits(joint_limits);
@@ -182,14 +181,16 @@ TEST_P(TrajectoryGeneratorPTPTest, missingVelocityLimits)
   LimitsContainer planner_limits;
 
   pilz::JointLimitsContainer joint_limits;
-  std::vector<std::string> joint_names = robot_model_->getJointModelGroup(planning_group_)->getActiveJointModelNames();
+  auto joint_models = robot_model_->getActiveJointModels();
   pilz_extensions::joint_limits_interface::JointLimits joint_limit;
   joint_limit.has_velocity_limits = false;
   joint_limit.has_acceleration_limits = true;
+  joint_limit.max_deceleration = -1;
   joint_limit.has_deceleration_limits = true;
-  for(const auto& joint_name : joint_names)
+  for(const auto& joint_model : joint_models)
   {
-    joint_limits.addLimit(joint_name, joint_limit);
+    ASSERT_TRUE(joint_limits.addLimit(joint_model->getName(), joint_limit)) << "Failed to add the limits for joint "
+                                                                            << joint_model->getName();
   }
 
   planner_limits.setJointLimits(joint_limits);
@@ -205,14 +206,15 @@ TEST_P(TrajectoryGeneratorPTPTest, missingDecelerationimits)
   LimitsContainer planner_limits;
 
   pilz::JointLimitsContainer joint_limits;
-  std::vector<std::string> joint_names = robot_model_->getJointModelGroup(planning_group_)->getActiveJointModelNames();
+  auto joint_models = robot_model_->getActiveJointModels();
   pilz_extensions::joint_limits_interface::JointLimits joint_limit;
   joint_limit.has_velocity_limits = true;
   joint_limit.has_acceleration_limits = true;
   joint_limit.has_deceleration_limits = false;
-  for(const auto& joint_name : joint_names)
+  for(const auto& joint_model : joint_models)
   {
-    joint_limits.addLimit(joint_name, joint_limit);
+    ASSERT_TRUE(joint_limits.addLimit(joint_model->getName(), joint_limit)) << "Failed to add the limits for joint "
+                                                                            << joint_model->getName();
   }
 
   planner_limits.setJointLimits(joint_limits);
@@ -222,8 +224,8 @@ TEST_P(TrajectoryGeneratorPTPTest, missingDecelerationimits)
 /**
  * @brief test the constructor when insufficient limits are given
  *  - Test Sequence:
- *    1. assign joint limit without acc and dec
- *    2. assign at least one joint limit will all required limits
+ *    1. assign joint limits without acc and dec
+ *    2. assign at least one joint limit per group with all required limits
  *
  *  - Expected Results:
  *    1. the constructor throws an exception of type TrajectoryGeneratorInvalidLimitsException
@@ -231,10 +233,8 @@ TEST_P(TrajectoryGeneratorPTPTest, missingDecelerationimits)
  */
 TEST_P(TrajectoryGeneratorPTPTest, testInsufficientLimit)
 {
-  // joint name
-  ASSERT_TRUE(robot_model_->getJointModelGroup(planning_group_)->getJointModelNames().size())
-      << "no joint exists in the planning group.";
-  std::string joint_name = robot_model_->getJointModelGroup(planning_group_)->getJointModelNames().front();
+  auto joint_models = robot_model_->getActiveJointModels();
+  ASSERT_TRUE(joint_models.size());
 
   // joint limit with insufficient limits (no acc/dec limits)
   pilz_extensions::joint_limits_interface::JointLimits insufficient_limit;
@@ -246,7 +246,11 @@ TEST_P(TrajectoryGeneratorPTPTest, testInsufficientLimit)
   insufficient_limit.has_acceleration_limits = false;
   insufficient_limit.has_deceleration_limits = false;
   JointLimitsContainer insufficient_joint_limits;
-  insufficient_joint_limits.addLimit(joint_name, insufficient_limit);
+  for(const auto& joint_model : joint_models)
+  {
+    ASSERT_TRUE(insufficient_joint_limits.addLimit(joint_model->getName(), insufficient_limit))
+      << "Failed to add the limits for joint " << joint_model->getName();
+  }
   LimitsContainer insufficient_planner_limits;
   insufficient_planner_limits.setJointLimits(insufficient_joint_limits);
 
@@ -262,7 +266,18 @@ TEST_P(TrajectoryGeneratorPTPTest, testInsufficientLimit)
   sufficient_limit.has_deceleration_limits = true;
   sufficient_limit.max_deceleration = -1;
   JointLimitsContainer sufficient_joint_limits;
-  sufficient_joint_limits.addLimit(joint_name, sufficient_limit);
+  for(auto jmg : robot_model_->getJointModelGroups())
+  {
+    auto joint_names {jmg->getActiveJointModelNames()};
+    ASSERT_TRUE(joint_names.size());
+    ASSERT_TRUE(sufficient_joint_limits.addLimit(joint_names.front(), sufficient_limit))
+      << "Failed to add the limits for joint " << joint_names.front();
+    for(auto it = std::next(joint_names.begin()); it != joint_names.end(); ++it)
+    {
+      ASSERT_TRUE(sufficient_joint_limits.addLimit((*it), insufficient_limit))
+        << "Failed to add the limits for joint " << (*it);
+    }
+  }
   LimitsContainer sufficient_planner_limits;
   sufficient_planner_limits.setJointLimits(sufficient_joint_limits);
 
@@ -472,6 +487,8 @@ TEST_P(TrajectoryGeneratorPTPTest, testScalingFactor)
   joint_limit.max_position = 3.132;
   joint_limit.min_position = -3.132;
   joint_limits.addLimit("prbt_joint_6", joint_limit);
+  // add gripper limit such that generator does not complain about missing limit
+  joint_limits.addLimit("prbt_gripper_finger_left_joint", joint_limit);
 
   pilz::LimitsContainer planner_limits;
   planner_limits.setJointLimits(joint_limits);

--- a/pilz_trajectory_generation/test/unittest_trajectory_generator_ptp.test
+++ b/pilz_trajectory_generation/test/unittest_trajectory_generator_ptp.test
@@ -19,8 +19,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
     <!-- Parametrized test running with and without gripper! -->
 
     <!-- Load the context with and without the pg70 -->
-    <include file="$(find prbt_moveit_config)/launch/test_context.launch" />
-    <include file="$(find prbt_moveit_config)/launch/test_context.launch">
+    <include file="$(find pilz_trajectory_generation)/test/test_robots/prbt/launch/test_context.launch" />
+    <include file="$(find pilz_trajectory_generation)/test/test_robots/prbt/launch/test_context.launch">
       <arg name="gripper" value="pg70" />
     </include>
 


### PR DESCRIPTION
* Fix handling of non-equal joint limits in PTP planner
* Adjust tests affected by the changes (needs [pilz_robots#94](https://github.com/PilzDE/pilz_robots/pull/94), therefore no CI before shadow release)
* Re-establish 100% line coverage of pilz_trajectory_generation