### PR TITLE
drop modules from install statement

### DIFF
--- a/pilz_robot_programming/CMakeLists.txt
+++ b/pilz_robot_programming/CMakeLists.txt
@@ -11,11 +11,9 @@ catkin_package()
 
 catkin_python_setup()
 
-install(PROGRAMS
+catkin_install_python(PROGRAMS
    examples/demo_program.py
    examples/demo_gripper_program.py
-   src/${PROJECT_NAME}/commands.py
-   src/${PROJECT_NAME}/robot.py
    DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
 )
 


### PR DESCRIPTION
only install scripts, not modules and use the suggested macro catkin_install_python,
see [catkin python howto](http://docs.ros.org/melodic/api/catkin/html/howto/format2/installing_python.html)