### PR TITLE
Switch active devel branch: kinetic->melodic

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ The FTP is implemented by Pilz GmbH & Co. KG.
 
 
 ### Note to Developers:
-`kinetic-devel` is considered to be the active development branch.
-Changes are merged into `melodic-devel` with every release or on demand.
+`melodic-devel` is considered to be the active development branch.
+Relevant changes are cherry-picked into `kinetic-devel` on a case-by-case basis.
 
 ## Package: pilz_trajectory_generation
 Provides the generators to create LIN, PTP and CIRC trajectories. All of these commands can be combined and

--- a/pilz_trajectory_generation/README.md
+++ b/pilz_trajectory_generation/README.md
@@ -190,7 +190,7 @@ The limits are expected to be under the namespace `<robot_description>_planning`
 E.g. if the urdf was loaded into `/robot_description` the cartesian limits have to be defined at `/robot_description_planning`.
 
 An example showing the cartesian limits which have to be defined can be found
-![here](https://github.com/PilzDE/pilz_robots/blob/kinetic-devel/prbt_moveit_config/config/cartesian_limits.yaml).
+![here](https://github.com/PilzDE/pilz_robots/blob/melodic-devel/prbt_moveit_config/config/cartesian_limits.yaml).
 
 # Sequence of multiple segments
 To concatenate multiple trajectories and plan the trajectory at once, you can use the sequence capability.

--- a/pilz_trajectory_generation/doc/MotionBlendAlgorithmDescription.tex
+++ b/pilz_trajectory_generation/doc/MotionBlendAlgorithmDescription.tex
@@ -111,6 +111,6 @@ For the sake of clarity, it is important to note that our functions for $u_{ij}(
 \begin{thebibliography}{9}
 \bibitem {lloyd1993trajectory}Lloyd, John and Hayward, Vincent \textit{Trajectory generation for sensor-driven and time-varying tasks}, The International journal of robotics research, 1993
 \bibitem {dantam2014orientation}Dantam, Neil and Stilman, Mike \textit{Spherical Parabolic Blends for Robot Workspace Trajectories}, International Conference on Intelligent Robots and Systems (IROS), 2014
-\bibitem{pilztrajectorygeneration}\url{https://github.com/PilzDE/pilz_industrial_motion/tree/kinetic-devel/pilz_trajectory_generation}
+\bibitem{pilztrajectorygeneration}\url{https://github.com/PilzDE/pilz_industrial_motion/tree/melodic-devel/pilz_trajectory_generation}
 \end{thebibliography}
 \end{document}


### PR DESCRIPTION
Updates ReadMe files

After this change I suppose that we simply open any new PR for melodic-devel. We can keep the old ones and merge one last time from kinetic->melodic after the next release.