### PR TITLE
WIP: Fix end-effector assumption in getTipFrame function

### DIFF
--- a/pilz_trajectory_generation/src/command_list_manager.cpp
+++ b/pilz_trajectory_generation/src/command_list_manager.cpp
@@ -108,7 +108,7 @@ bool CommandListManager::checkRadiiForOverlap(const robot_trajectory::RobotTraje
     return false;
   }
 
-  const std::string& blend_frame {getTipFrame(model_->getJointModelGroup(traj_A.getGroupName()))};
+  const std::string& blend_frame {getSolverTipFrame(model_->getJointModelGroup(traj_A.getGroupName()))};
   auto distance_endpoints = (traj_A.getLastWayPoint().getFrameTransform(blend_frame).translation() -
                              traj_B.getLastWayPoint().getFrameTransform(blend_frame).translation()).norm();
   return distance_endpoints <= sum_radii;
@@ -175,10 +175,10 @@ bool CommandListManager::isInvalidBlendRadii(const moveit::core::RobotModel &mod
     return true;
   }
 
-  // No blending between end-effectors
-  if (model.getJointModelGroup(item_A.req.group_name)->isEndEffector())
+  // No blending for groups without solver
+  if(!hasSolver(model.getJointModelGroup(item_A.req.group_name)))
   {
-    ROS_WARN_STREAM("Blending between end-effector commands not allowed");
+    ROS_WARN_STREAM("Blending for groups without solver not allowed");
     return true;
   }
 

--- a/pilz_trajectory_generation/src/plan_components_builder.cpp
+++ b/pilz_trajectory_generation/src/plan_components_builder.cpp
@@ -67,7 +67,7 @@ void PlanComponentsBuilder::blend(robot_trajectory::RobotTrajectoryPtr other,
   blend_request.second_trajectory = other;
   blend_request.blend_radius = blend_radius;
   blend_request.group_name = traj_tail_->getGroupName();
-  blend_request.link_name = getTipFrame(model_->getJointModelGroup(blend_request.group_name));
+  blend_request.link_name = getSolverTipFrame(model_->getJointModelGroup(blend_request.group_name));
 
   pilz::TrajectoryBlendResponse blend_response;
   if (!blender_->blend(blend_request, blend_response))

--- a/pilz_trajectory_generation/test/integrationtest_command_list_manager.cpp
+++ b/pilz_trajectory_generation/test/integrationtest_command_list_manager.cpp
@@ -624,12 +624,12 @@ TEST_F(IntegrationTestCommandListManager, TestGroupSpecificStartState)
 
 /**
  * @brief Checks that exception is thrown if Tip-Frame is requested for
- * an end-effector.
+ * a group without a solver.
  */
-TEST_F(IntegrationTestCommandListManager, TestTipFrameNoEndEffector)
+TEST_F(IntegrationTestCommandListManager, TestGetSolverTipFrameForSolverlessGroup)
 {
   Gripper gripper_cmd {data_loader_->getGripper("open_gripper")};
-  EXPECT_THROW(getTipFrame(robot_model_->getJointModelGroup(gripper_cmd.getPlanningGroup())), EndEffectorException);
+  EXPECT_THROW(getSolverTipFrame(robot_model_->getJointModelGroup(gripper_cmd.getPlanningGroup())), NoSolverException);
 }
 
 int main(int argc, char **argv)


### PR DESCRIPTION
The name of the function and the actual functionality of the getTipFrame
function was confusing. Therefore, the function name and the functionality
was adapted. Depending code was changed accordingly.