### PR TITLE
added methods for 'with' usage to Robot

### DIFF
--- a/pilz_robot_programming/src/pilz_robot_programming/robot.py
+++ b/pilz_robot_programming/src/pilz_robot_programming/robot.py
@@ -433,6 +433,12 @@ class Robot(object):
             rospy.logdebug("Delete single instance parameter from parameter server.")
             rospy.delete_param(self._INSTANCE_PARAM)
 
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.__del__()
+
     def __del__(self):
         rospy.logdebug("Dtor called")
         self._release()


### PR DESCRIPTION
Since the only save way, other than deleting the node, to free the Robot instance is to call its deconstructor "__del__()" id suggest to add the context_guard.

With it the Robot can savely be used for some motion and freed again within a node like:
```
with Robot('1') as rob:
   rob.move(...)

r = Robot('1') # would work here
```

This is relevant to switch robot control between several nodes.

