### PR TITLE
speed up travis builds using ccache

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,10 @@ sudo: required
 dist: trusty
 language: generic
 
+cache:
+  directories:
+    - $HOME/.ccache
+
 notifications:
   email:
     on_failure: always
@@ -15,6 +19,7 @@ notifications:
 env:
   global:
     - AFTER_SCRIPT='apt list --installed | grep "^ros-"'
+    - CCACHE_DIR=$HOME/.ccache
   matrix:
     - ROS_DISTRO="melodic" ROS_REPO=ros CATKIN_LINT=true
     - ROS_DISTRO="melodic" ROS_REPO=ros-shadow-fixed CATKIN_LINT=true


### PR DESCRIPTION
See https://github.com/ros-industrial/industrial_ci/blob/master/doc/index.rst#cache-build-artifacts-to-speed-up-the-subsequent-builds-if-any