### PR TITLE
remove misplaced changelog entry

### DIFF
--- a/pilz_industrial_motion_testutils/CHANGELOG.rst
+++ b/pilz_industrial_motion_testutils/CHANGELOG.rst
@@ -8,9 +8,6 @@ Changelog for package pilz_industrial_motion_testutils
 * Add missing intialization
 * Add getter for CircJointInterimCart in XMLTestdataLoader
 
-0.4.1 (2019-02-27)
-------------------
-
 0.3.6 (2019-02-26)
 ------------------
 


### PR DESCRIPTION
Bloom-release told me that this is a mistake, therefore fixing it before release.