### PR TITLE
pass planning pipeline from context to solve()

### DIFF
--- a/pilz_trajectory_generation/include/pilz_trajectory_generation/command_list_manager.h
+++ b/pilz_trajectory_generation/include/pilz_trajectory_generation/command_list_manager.h
@@ -22,6 +22,7 @@
 #include <boost/optional.hpp>
 
 #include <moveit/planning_interface/planning_interface.h>
+#include <moveit/planning_pipeline/planning_pipeline.h>
 #include <moveit_msgs/MotionPlanResponse.h>
 
 #include "pilz_msgs/MotionSequenceRequest.h"
@@ -81,7 +82,8 @@ public:
    * @return Contains the calculated/generated trajectories.
    */
   RobotTrajCont solve(const planning_scene::PlanningSceneConstPtr& planning_scene,
-                       const pilz_msgs::MotionSequenceRequest& req_list);
+                      planning_pipeline::PlanningPipelinePtr planning_pipeline,
+                      const pilz_msgs::MotionSequenceRequest& req_list);
 
 private:
   using MotionResponseCont = std::vector<planning_interface::MotionPlanResponse>;
@@ -108,6 +110,7 @@ private:
    * @return Container of generated trajectories.
    */
   MotionResponseCont solveSequenceItems(const planning_scene::PlanningSceneConstPtr& planning_scene,
+                                        planning_pipeline::PlanningPipelinePtr planning_pipeline,
                                         const pilz_msgs::MotionSequenceRequest &req_list) const;
 
   /**

--- a/pilz_trajectory_generation/src/command_list_manager.cpp
+++ b/pilz_trajectory_generation/src/command_list_manager.cpp
@@ -59,7 +59,8 @@ CommandListManager::CommandListManager(const ros::NodeHandle &nh, const moveit::
 }
 
 RobotTrajCont CommandListManager::solve(const planning_scene::PlanningSceneConstPtr& planning_scene,
-                                         const pilz_msgs::MotionSequenceRequest& req_list)
+                                        planning_pipeline::PlanningPipelinePtr planning_pipeline,
+                                        const pilz_msgs::MotionSequenceRequest& req_list)
 {
   if(req_list.items.empty())
   {
@@ -72,7 +73,7 @@ RobotTrajCont CommandListManager::solve(const planning_scene::PlanningSceneConst
 
   MotionResponseCont resp_cont
   {
-    solveSequenceItems(planning_scene, req_list)
+    solveSequenceItems(planning_scene, planning_pipeline, req_list)
   };
 
   assert(model_);
@@ -203,10 +204,10 @@ CommandListManager::RadiiCont CommandListManager::extractBlendRadii(const moveit
 
 CommandListManager::MotionResponseCont CommandListManager::solveSequenceItems(
     const planning_scene::PlanningSceneConstPtr& planning_scene,
+    planning_pipeline::PlanningPipelinePtr planning_pipeline,
     const pilz_msgs::MotionSequenceRequest &req_list) const
 {
   MotionResponseCont motion_plan_responses;
-  planning_pipeline::PlanningPipelinePtr planning_pipeline(new planning_pipeline::PlanningPipeline(model_, nh_));
   size_t curr_req_index {0};
   const size_t num_req {req_list.items.size()};
   for(const auto& seq_item : req_list.items)

--- a/pilz_trajectory_generation/src/move_group_sequence_action.cpp
+++ b/pilz_trajectory_generation/src/move_group_sequence_action.cpp
@@ -61,6 +61,7 @@ MoveGroupSequenceAction::MoveGroupSequenceAction()
 void MoveGroupSequenceAction::initialize()
 {
   // start the move action server
+  ROS_INFO_STREAM("initialize move group sequence action");
   move_action_server_.reset( new actionlib::SimpleActionServer<pilz_msgs::MoveGroupSequenceAction>(
                                root_node_handle_, "sequence_move_group",
                                boost::bind(&MoveGroupSequenceAction::executeSequenceCallback, this, _1), false) );
@@ -183,7 +184,7 @@ void MoveGroupSequenceAction::executeMoveCallback_PlanOnly(const pilz_msgs::Move
   RobotTrajCont traj_vec;
   try
   {
-    traj_vec = command_list_manager_->solve(the_scene, goal->request);
+    traj_vec = command_list_manager_->solve(the_scene, context_->planning_pipeline_, goal->request);
   }
   catch(const MoveItErrorCodeException& ex)
   {
@@ -220,7 +221,7 @@ bool MoveGroupSequenceAction::planUsingSequenceManager(const pilz_msgs::MotionSe
 
   planning_scene_monitor::LockedPlanningSceneRO lscene(plan.planning_scene_monitor_);
   RobotTrajCont traj_vec;
-  try { traj_vec = command_list_manager_->solve(plan.planning_scene_, req); }
+  try { traj_vec = command_list_manager_->solve(plan.planning_scene_, context_->planning_pipeline_, req); }
   catch(const MoveItErrorCodeException& ex)
   {
     ROS_ERROR_STREAM("Planning pipeline threw an exception (error code: "

--- a/pilz_trajectory_generation/src/move_group_sequence_service.cpp
+++ b/pilz_trajectory_generation/src/move_group_sequence_service.cpp
@@ -71,7 +71,7 @@ bool MoveGroupSequenceService::plan(pilz_msgs::GetMotionSequence::Request& req,
 
   ros::Time planning_start = ros::Time::now();
   RobotTrajCont traj_vec;
-  try { traj_vec = command_list_manager_->solve(ps, req.commands); }
+  try { traj_vec = command_list_manager_->solve(ps, context_->planning_pipeline_, req.commands); }
   catch(const MoveItErrorCodeException& ex)
   {
     ROS_ERROR_STREAM("Planner threw an exception (error code: "

--- a/pilz_trajectory_generation/test/integrationtest_command_list_manager.cpp
+++ b/pilz_trajectory_generation/test/integrationtest_command_list_manager.cpp
@@ -80,6 +80,7 @@ protected:
     robot_model_loader::RobotModelLoader(ROBOT_DESCRIPTION_STR).getModel() };
   std::shared_ptr<pilz_trajectory_generation::CommandListManager> manager_;
   planning_scene::PlanningScenePtr scene_;
+  planning_pipeline::PlanningPipelinePtr pipeline_;
 
   std::unique_ptr<pilz_industrial_motion_testutils::TestdataLoader> data_loader_;
 };
@@ -100,8 +101,9 @@ void IntegrationTestCommandListManager::SetUp()
   ASSERT_NE(nullptr, data_loader_) << "Failed to load test data by provider.";
 
   // Define and set the current scene and manager test object
-  scene_ = std::make_shared<planning_scene::PlanningScene>(robot_model_);
   manager_ = std::make_shared<pilz_trajectory_generation::CommandListManager>(ph_, robot_model_);
+  scene_ = std::make_shared<planning_scene::PlanningScene>(robot_model_);
+  pipeline_ = std::make_shared<planning_pipeline::PlanningPipeline>(robot_model_, ph_);
 }
 
 /**
@@ -154,7 +156,7 @@ TEST_F(IntegrationTestCommandListManager, concatThreeSegments)
   seq.erase(3, seq.size());
   seq.setAllBlendRadiiToZero();
 
-  RobotTrajCont res123_vec {manager_->solve(scene_, seq.toRequest())};
+  RobotTrajCont res123_vec {manager_->solve(scene_, pipeline_, seq.toRequest())};
   EXPECT_EQ(res123_vec.size(), 1u);
   EXPECT_GT(res123_vec.front()->getWayPointCount(), 0u);
   EXPECT_TRUE(hasStrictlyIncreasingTime(res123_vec.front())) << "Time steps not strictly positively increasing";
@@ -164,7 +166,7 @@ TEST_F(IntegrationTestCommandListManager, concatThreeSegments)
   req_1.items.resize(1);
   req_1.items.at(0).req = seq.getCmd(0).toRequest();
   req_1.items.at(0).blend_radius = 0.;
-  RobotTrajCont res1_vec {manager_->solve(scene_, req_1)};
+  RobotTrajCont res1_vec {manager_->solve(scene_, pipeline_, req_1)};
   EXPECT_EQ(res1_vec.size(), 1u);
   EXPECT_GT(res1_vec.front()->getWayPointCount(), 0u);
   EXPECT_EQ(res1_vec.front()->getFirstWayPoint().getVariableCount(),
@@ -175,7 +177,7 @@ TEST_F(IntegrationTestCommandListManager, concatThreeSegments)
   req_2.items.resize(1);
   req_2.items.at(0).req = seq.getCmd(1).toRequest();
   req_2.items.at(0).blend_radius = 0.;
-  RobotTrajCont res2_vec {manager_->solve(scene_, req_2)};
+  RobotTrajCont res2_vec {manager_->solve(scene_, pipeline_, req_2)};
   EXPECT_EQ(res2_vec.size(), 1u);
   EXPECT_GT(res2_vec.front()->getWayPointCount(), 0u);
   EXPECT_EQ(res2_vec.front()->getFirstWayPoint().getVariableCount(),
@@ -187,7 +189,7 @@ TEST_F(IntegrationTestCommandListManager, concatThreeSegments)
   req_3.items.resize(1);
   req_3.items.at(0).req = seq.getCmd(2).toRequest();
   req_3.items.at(0).blend_radius = 0.;
-  RobotTrajCont res3_vec {manager_->solve(scene_, req_3)};
+  RobotTrajCont res3_vec {manager_->solve(scene_, pipeline_, req_3)};
   EXPECT_EQ(res3_vec.size(), 1u);
   EXPECT_GT(res3_vec.front()->getWayPointCount(), 0u);
   EXPECT_EQ(res3_vec.front()->getFirstWayPoint().getVariableCount(),
@@ -224,14 +226,14 @@ TEST_F(IntegrationTestCommandListManager, concatSegmentsSelectiveBlending)
   seq.erase(3, seq.size());
   seq.setAllBlendRadiiToZero();
   seq.setBlendRadius(0, 0.1);
-  RobotTrajCont res1 {manager_->solve(scene_, seq.toRequest())};
+  RobotTrajCont res1 {manager_->solve(scene_, pipeline_, seq.toRequest())};
   EXPECT_EQ(res1.size(), 1u);
   EXPECT_GT(res1.front()->getWayPointCount(), 0u);
   EXPECT_TRUE(hasStrictlyIncreasingTime(res1.front())) << "Time steps not strictly positively increasing";
 
   seq.setAllBlendRadiiToZero();
   seq.setBlendRadius(1, 0.1);
-  RobotTrajCont res2 {manager_->solve(scene_, seq.toRequest())};
+  RobotTrajCont res2 {manager_->solve(scene_, pipeline_, seq.toRequest())};
   EXPECT_EQ(res2.size(), 1u);
   EXPECT_GT(res2.front()->getWayPointCount(), 0u);
   EXPECT_TRUE(hasStrictlyIncreasingTime(res2.front())) << "Time steps not strictly positively increasing";
@@ -253,7 +255,7 @@ TEST_F(IntegrationTestCommandListManager, concatTwoPtpSegments)
   ASSERT_GE(seq.size(), 2u);
   seq.setAllBlendRadiiToZero();
 
-  RobotTrajCont res_vec {manager_->solve(scene_, seq.toRequest())};
+  RobotTrajCont res_vec {manager_->solve(scene_, pipeline_, seq.toRequest())};
   EXPECT_EQ(res_vec.size(), 1u);
   EXPECT_GT(res_vec.front()->getWayPointCount(), 0u);
   EXPECT_TRUE(hasStrictlyIncreasingTime(res_vec.front()));
@@ -275,7 +277,7 @@ TEST_F(IntegrationTestCommandListManager, concatPtpAndLinSegments)
   ASSERT_GE(seq.size(), 2u);
   seq.setAllBlendRadiiToZero();
 
-  RobotTrajCont res_vec {manager_->solve(scene_, seq.toRequest())};
+  RobotTrajCont res_vec {manager_->solve(scene_, pipeline_, seq.toRequest())};
   EXPECT_EQ(res_vec.size(), 1u);
   EXPECT_GT(res_vec.front()->getWayPointCount(), 0u);
   EXPECT_TRUE(hasStrictlyIncreasingTime(res_vec.front()));
@@ -297,7 +299,7 @@ TEST_F(IntegrationTestCommandListManager, concatLinAndPtpSegments)
   ASSERT_GE(seq.size(), 2u);
   seq.setAllBlendRadiiToZero();
 
-  RobotTrajCont res_vec {manager_->solve(scene_, seq.toRequest())};
+  RobotTrajCont res_vec {manager_->solve(scene_, pipeline_, seq.toRequest())};
   EXPECT_EQ(res_vec.size(), 1u);
   EXPECT_GT(res_vec.front()->getWayPointCount(), 0u);
   EXPECT_TRUE(hasStrictlyIncreasingTime(res_vec.front()));
@@ -317,7 +319,7 @@ TEST_F(IntegrationTestCommandListManager, blendTwoSegments)
   Sequence seq {data_loader_->getSequence("SimpleSequence")};
   ASSERT_EQ(seq.size(), 2u);
   pilz_msgs::MotionSequenceRequest req {seq.toRequest()};
-  RobotTrajCont res_vec {manager_->solve(scene_, req)};
+  RobotTrajCont res_vec {manager_->solve(scene_, pipeline_, req)};
   EXPECT_EQ(res_vec.size(), 1u);
   EXPECT_GT(res_vec.front()->getWayPointCount(), 0u);
   EXPECT_EQ(res_vec.front()->getFirstWayPoint().getVariableCount(),
@@ -352,7 +354,7 @@ TEST_F(IntegrationTestCommandListManager, blendTwoSegments)
 TEST_F(IntegrationTestCommandListManager, emptyList)
 {
   pilz_msgs::MotionSequenceRequest empty_list;
-  RobotTrajCont res_vec {manager_->solve(scene_, empty_list)};
+  RobotTrajCont res_vec {manager_->solve(scene_, pipeline_, empty_list)};
   EXPECT_TRUE(res_vec.empty());
 }
 
@@ -371,7 +373,7 @@ TEST_F(IntegrationTestCommandListManager, firstGoalNotReachable)
   ASSERT_GE(seq.size(), 2u);
   LinCart& lin {seq.getCmd<LinCart>(0)};
   lin.getGoalConfiguration().getPose().position.y = 2700;
-  EXPECT_THROW(manager_->solve(scene_, seq.toRequest()), PlanningPipelineException);
+  EXPECT_THROW(manager_->solve(scene_, pipeline_, seq.toRequest()), PlanningPipelineException);
 }
 
 /**
@@ -390,7 +392,7 @@ TEST_F(IntegrationTestCommandListManager, startStateNotFirstGoal)
   const LinCart& lin {seq.getCmd<LinCart>(0)};
   pilz_msgs::MotionSequenceRequest req {seq.toRequest()};
   req.items.at(1).req.start_state = lin.getGoalConfiguration().toMoveitMsgsRobotState();
-  EXPECT_THROW(manager_->solve(scene_, req), StartStateSetException);
+  EXPECT_THROW(manager_->solve(scene_, pipeline_, req), StartStateSetException);
 }
 
 /**
@@ -408,7 +410,7 @@ TEST_F(IntegrationTestCommandListManager, blendingRadiusNegative)
   Sequence seq {data_loader_->getSequence("SimpleSequence")};
   ASSERT_GE(seq.size(), 2u);
   seq.setBlendRadius(0,-0.3);
-  EXPECT_THROW(manager_->solve(scene_, seq.toRequest()), NegativeBlendRadiusException);
+  EXPECT_THROW(manager_->solve(scene_, pipeline_, seq.toRequest()), NegativeBlendRadiusException);
 }
 
 /**
@@ -426,7 +428,7 @@ TEST_F(IntegrationTestCommandListManager, lastBlendingRadiusNonZero)
   Sequence seq {data_loader_->getSequence("SimpleSequence")};
   ASSERT_EQ(seq.size(), 2u);
   seq.setBlendRadius(1, 0.03);
-  EXPECT_THROW(manager_->solve(scene_, seq.toRequest()), LastBlendRadiusNotZeroException);
+  EXPECT_THROW(manager_->solve(scene_, pipeline_, seq.toRequest()), LastBlendRadiusNotZeroException);
 }
 
 /**
@@ -445,7 +447,7 @@ TEST_F(IntegrationTestCommandListManager, blendRadiusGreaterThanSegment)
   Sequence seq {data_loader_->getSequence("SimpleSequence")};
   ASSERT_GE(seq.size(), 2u);
   seq.setBlendRadius(0, 42.0);
-  EXPECT_THROW(manager_->solve(scene_, seq.toRequest()), BlendingFailedException);
+  EXPECT_THROW(manager_->solve(scene_, pipeline_, seq.toRequest()), BlendingFailedException);
 }
 
 /**
@@ -466,7 +468,7 @@ TEST_F(IntegrationTestCommandListManager, blendingRadiusOverlapping)
   ASSERT_GE(seq.size(), 3u);
   seq.erase(3, seq.size());
 
-  RobotTrajCont res_valid_vec {manager_->solve(scene_, seq.toRequest())};
+  RobotTrajCont res_valid_vec {manager_->solve(scene_, pipeline_, seq.toRequest())};
   EXPECT_EQ(res_valid_vec.size(), 1u);
   EXPECT_GT(res_valid_vec.front()->getWayPointCount(), 0u);
 
@@ -479,7 +481,7 @@ TEST_F(IntegrationTestCommandListManager, blendingRadiusOverlapping)
   auto distance = (p2.translation()-p1.translation()).norm();
 
   seq.setBlendRadius(1, (distance - seq.getBlendRadius(0) + 0.01) ); // overlapping radii
-  EXPECT_THROW(manager_->solve(scene_, seq.toRequest()), OverlappingBlendRadiiException);
+  EXPECT_THROW(manager_->solve(scene_, pipeline_, seq.toRequest()), OverlappingBlendRadiiException);
 }
 
 /**
@@ -500,7 +502,7 @@ TEST_F(IntegrationTestCommandListManager, TestExecutionTime)
 {
   Sequence seq {data_loader_->getSequence("ComplexSequence")};
   ASSERT_GE(seq.size(), 2u);
-  RobotTrajCont res_single_vec {manager_->solve(scene_, seq.toRequest())};
+  RobotTrajCont res_single_vec {manager_->solve(scene_, pipeline_, seq.toRequest())};
   EXPECT_EQ(res_single_vec.size(), 1u);
   EXPECT_GT(res_single_vec.front()->getWayPointCount(), 0u);
 
@@ -520,7 +522,7 @@ TEST_F(IntegrationTestCommandListManager, TestExecutionTime)
     req.items.push_back(item);
   }
 
-  RobotTrajCont res_n_vec {manager_->solve(scene_, req)};
+  RobotTrajCont res_n_vec {manager_->solve(scene_, pipeline_, req)};
   EXPECT_EQ(res_n_vec.size(), 1u);
   EXPECT_GT(res_n_vec.front()->getWayPointCount(), 0u);
 
@@ -558,7 +560,7 @@ TEST_F(IntegrationTestCommandListManager, TestDifferentGroups)
     }
   }
 
-  RobotTrajCont res_single_vec {manager_->solve(scene_, seq.toRequest())};
+  RobotTrajCont res_single_vec {manager_->solve(scene_, pipeline_, seq.toRequest())};
   EXPECT_EQ(res_single_vec.size(), num_groups);
   for(RobotTrajCont::size_type i = 0; i<res_single_vec.size(); ++i)
   {
@@ -580,7 +582,7 @@ TEST_F(IntegrationTestCommandListManager, TestGripperCmdBlending)
 
   // Ensure that blending is requested for gripper commands.
   seq.setBlendRadius(0, 1.0);
-  RobotTrajCont res_vec {manager_->solve(scene_, seq.toRequest())};
+  RobotTrajCont res_vec {manager_->solve(scene_, pipeline_, seq.toRequest())};
   EXPECT_EQ(res_vec.size(), 1u);
 }
 
@@ -617,7 +619,7 @@ TEST_F(IntegrationTestCommandListManager, TestGroupSpecificStartState)
   // of joints of the manipulator group without the gripper
   ptp.getStartConfiguration().clearModel();
 
-  RobotTrajCont res_vec {manager_->solve(scene_, seq.toRequest())};
+  RobotTrajCont res_vec {manager_->solve(scene_, pipeline_, seq.toRequest())};
   EXPECT_GE(res_vec.size(), 1u);
   EXPECT_GT(res_vec.front()->getWayPointCount(), 0u);
 }


### PR DESCRIPTION
to avoid re-initialization of a new planning pipeline for every request

Fixes #169