### PR TITLE
check for link name during request validation

### DIFF
--- a/pilz_trajectory_generation/src/trajectory_blender_transition_window.cpp
+++ b/pilz_trajectory_generation/src/trajectory_blender_transition_window.cpp
@@ -135,6 +135,15 @@ bool pilz::TrajectoryBlenderTransitionWindow::validateRequest(const pilz::Trajec
     return false;
   }
 
+  // check link exists
+  if (!req.first_trajectory->getRobotModel()->hasLinkModel(req.link_name) &&
+      !req.first_trajectory->getLastWayPoint().hasAttachedBody(req.link_name))
+  {
+    ROS_ERROR_STREAM("Unknown link name: " << req.link_name);
+    error_code.val = moveit_msgs::MoveItErrorCodes::INVALID_LINK_NAME;
+    return false;
+  }
+
   if(req.blend_radius <=0 )
   {
     ROS_ERROR("Blending radius must be positive");


### PR DESCRIPTION
instead of spitting thousands of ERRORS during intersection point search

Trying to lookup the transform spits an error but does not throw, so the intersection search goes through the whole trajectory: [See Travis jobs](https://travis-ci.org/PilzDE/pilz_industrial_motion/jobs/537648379#L7483-L8134)

This PR checks for existance of the link in advance during request validation.

- [x]  Check line coverage:
  This PR does not change the coverage. Previously uncovered and still uncovered lines (copy into new issue?):
  https://github.com/PilzDE/pilz_industrial_motion/blob/5a1bd1c2d2d6d5f3a2c9aa3156bd097b49f0eadd/pilz_trajectory_generation/src/trajectory_generator_lin.cpp#L160-L162