### PR TITLE
drop deprecated isRobotStateEqual()

### DIFF
--- a/pilz_trajectory_generation/include/pilz_trajectory_generation/trajectory_functions.h
+++ b/pilz_trajectory_generation/include/pilz_trajectory_generation/trajectory_functions.h
@@ -165,17 +165,6 @@ bool determineAndCheckSamplingTime(const robot_trajectory::RobotTrajectoryPtr& f
                                    double& sampling_time);
 
 /**
- * @brief Deprecated, do not use this function signature anymore.
- *
- * @deprecated use the other function signature taking const references to the robot states.
- *
- */
-bool isRobotStateEqual(const robot_state::RobotStatePtr& state1,
-                       const robot_state::RobotStatePtr& state2,
-                       const std::string& joint_group_name,
-                       double epsilon);
-
-/**
  * @brief Check if the two robot states have the same joint position/velocity/acceleration.
  *
  * @param joint_group_name The name of the joint group.
@@ -196,7 +185,7 @@ bool isRobotStateEqual(const robot_state::RobotState& state1,
  * @param EPSILON
  * @return
  */
-bool isRobotStateStationary(const robot_state::RobotStatePtr& state,
+bool isRobotStateStationary(const robot_state::RobotState& state,
                             const std::string& group,
                             double EPSILON);
 

--- a/pilz_trajectory_generation/src/trajectory_blender_transition_window.cpp
+++ b/pilz_trajectory_generation/src/trajectory_blender_transition_window.cpp
@@ -143,8 +143,8 @@ bool pilz::TrajectoryBlenderTransitionWindow::validateRequest(const pilz::Trajec
   }
 
   // end position of the first trajectory and start position of second trajectory must be the same
-  if(!pilz::isRobotStateEqual(req.first_trajectory->getLastWayPointPtr(),
-                              req.second_trajectory->getFirstWayPointPtr(),
+  if(!pilz::isRobotStateEqual(req.first_trajectory->getLastWayPoint(),
+                              req.second_trajectory->getFirstWayPoint(),
                               req.group_name,
                               EPSILON))
   {
@@ -167,8 +167,8 @@ bool pilz::TrajectoryBlenderTransitionWindow::validateRequest(const pilz::Trajec
   }
 
   //end position of the first trajectory and start position of second trajectory must have zero velocities/accelerations
-  if(!pilz::isRobotStateStationary(req.first_trajectory->getLastWayPointPtr(), req.group_name, EPSILON) ||
-     !pilz::isRobotStateStationary(req.second_trajectory->getFirstWayPointPtr(), req.group_name, EPSILON) )
+  if(!pilz::isRobotStateStationary(req.first_trajectory->getLastWayPoint(), req.group_name, EPSILON) ||
+     !pilz::isRobotStateStationary(req.second_trajectory->getFirstWayPoint(), req.group_name, EPSILON) )
   {
     ROS_ERROR("Intersection point of the blending trajectories has non-zero velocities/accelerations.");
     error_code.val = moveit_msgs::MoveItErrorCodes::INVALID_MOTION_PLAN;

--- a/pilz_trajectory_generation/src/trajectory_functions.cpp
+++ b/pilz_trajectory_generation/src/trajectory_functions.cpp
@@ -468,15 +468,6 @@ bool pilz::determineAndCheckSamplingTime(const robot_trajectory::RobotTrajectory
   return true;
 }
 
-bool pilz::isRobotStateEqual(const moveit::core::RobotStatePtr &state1,
-                             const moveit::core::RobotStatePtr &state2,
-                             const std::string &joint_group_name,
-                             double epsilon)
-{
-  ROS_WARN("This signature of isRobotStateEqual is deprecated. Please use the new one in the future.");
-  return isRobotStateEqual(*state1, *state2, joint_group_name, epsilon);
-}
-
 bool pilz::isRobotStateEqual(const moveit::core::RobotState &state1,
                              const moveit::core::RobotState &state2,
                              const std::string &joint_group_name,
@@ -521,18 +512,18 @@ bool pilz::isRobotStateEqual(const moveit::core::RobotState &state1,
   return true;
 }
 
-bool pilz::isRobotStateStationary(const moveit::core::RobotStatePtr &state,
+bool pilz::isRobotStateStationary(const moveit::core::RobotState &state,
                                   const std::string &group,
                                   double EPSILON)
 {
   Eigen::VectorXd joint_variable;
-  state->copyJointGroupVelocities(group, joint_variable);
+  state.copyJointGroupVelocities(group, joint_variable);
   if(joint_variable.norm() > EPSILON)
   {
     ROS_DEBUG("Joint velocities are not zero.");
     return false;
   }
-  state->copyJointGroupAccelerations(group, joint_variable);
+  state.copyJointGroupAccelerations(group, joint_variable);
   if(joint_variable.norm() > EPSILON)
   {
     ROS_DEBUG("Joint accelerations are not zero.");

--- a/pilz_trajectory_generation/test/unittest_trajectory_functions.cpp
+++ b/pilz_trajectory_generation/test/unittest_trajectory_functions.cpp
@@ -854,14 +854,14 @@ TEST_P(TrajectoryFunctionsTestFlangeAndGripper, testDetermineAndCheckSamplingTim
  */
 TEST_P(TrajectoryFunctionsTestFlangeAndGripper, testIsRobotStateEqualPositionUnequal)
 {
-  robot_state::RobotStatePtr rstate_1 = std::make_shared<robot_state::RobotState>(robot_model_);
-  robot_state::RobotStatePtr rstate_2 = std::make_shared<robot_state::RobotState>(robot_model_);
+  robot_state::RobotState rstate_1 = robot_state::RobotState(robot_model_);
+  robot_state::RobotState rstate_2 = robot_state::RobotState(robot_model_);
 
   double default_joint_position [6] = {0.0, 0.0, 0.0, 0.0, 0.0, 0.0};
-  rstate_1->setJointGroupPositions(planning_group_, default_joint_position);
+  rstate_1.setJointGroupPositions(planning_group_, default_joint_position);
   // Ensure that the joint positions of both robot states are different
   default_joint_position[0] = default_joint_position[0] + 70.0;
-  rstate_2->setJointGroupPositions(planning_group_, default_joint_position);
+  rstate_2.setJointGroupPositions(planning_group_, default_joint_position);
 
   double epsilon {0.0001};
   EXPECT_FALSE( pilz::isRobotStateEqual(rstate_1, rstate_2, planning_group_, epsilon) );
@@ -880,19 +880,19 @@ TEST_P(TrajectoryFunctionsTestFlangeAndGripper, testIsRobotStateEqualPositionUne
  */
 TEST_P(TrajectoryFunctionsTestFlangeAndGripper, testIsRobotStateEqualVelocityUnequal)
 {
-  robot_state::RobotStatePtr rstate_1 = std::make_shared<robot_state::RobotState>(robot_model_);
-  robot_state::RobotStatePtr rstate_2 = std::make_shared<robot_state::RobotState>(robot_model_);
+  robot_state::RobotState rstate_1 = robot_state::RobotState(robot_model_);
+  robot_state::RobotState rstate_2 = robot_state::RobotState(robot_model_);
 
   // Ensure that the joint positions of both robot state are equal
   double default_joint_position [6] = {0.0, 0.0, 0.0, 0.0, 0.0, 0.0};
-  rstate_1->setJointGroupPositions(planning_group_, default_joint_position);
-  rstate_2->setJointGroupPositions(planning_group_, default_joint_position);
+  rstate_1.setJointGroupPositions(planning_group_, default_joint_position);
+  rstate_2.setJointGroupPositions(planning_group_, default_joint_position);
 
   double default_joint_velocity [6] = {0.0, 0.0, 0.0, 0.0, 0.0, 0.0};
-  rstate_1->setJointGroupVelocities(planning_group_, default_joint_velocity);
+  rstate_1.setJointGroupVelocities(planning_group_, default_joint_velocity);
   // Ensure that the joint velocites of both robot states are different
   default_joint_velocity[1]  = default_joint_velocity[1] + 10.0;
-  rstate_2->setJointGroupVelocities(planning_group_, default_joint_velocity);
+  rstate_2.setJointGroupVelocities(planning_group_, default_joint_velocity);
 
   double epsilon {0.0001};
   EXPECT_FALSE( pilz::isRobotStateEqual(rstate_1, rstate_2, planning_group_, epsilon) );
@@ -911,24 +911,24 @@ TEST_P(TrajectoryFunctionsTestFlangeAndGripper, testIsRobotStateEqualVelocityUne
  */
 TEST_P(TrajectoryFunctionsTestFlangeAndGripper, testIsRobotStateEqualAccelerationUnequal)
 {
-  robot_state::RobotStatePtr rstate_1 = std::make_shared<robot_state::RobotState>(robot_model_);
-  robot_state::RobotStatePtr rstate_2 = std::make_shared<robot_state::RobotState>(robot_model_);
+  robot_state::RobotState rstate_1 = robot_state::RobotState(robot_model_);
+  robot_state::RobotState rstate_2 = robot_state::RobotState(robot_model_);
 
   // Ensure that the joint positions of both robot state are equal
   double default_joint_position [6] = {0.0, 0.0, 0.0, 0.0, 0.0, 0.0};
-  rstate_1->setJointGroupPositions(planning_group_, default_joint_position);
-  rstate_2->setJointGroupPositions(planning_group_, default_joint_position);
+  rstate_1.setJointGroupPositions(planning_group_, default_joint_position);
+  rstate_2.setJointGroupPositions(planning_group_, default_joint_position);
 
   // Ensure that the joint velocities of both robot state are equal
   double default_joint_velocity [6] = {0.0, 0.0, 0.0, 0.0, 0.0, 0.0};
-  rstate_1->setJointGroupVelocities(planning_group_, default_joint_velocity);
-  rstate_2->setJointGroupVelocities(planning_group_, default_joint_velocity);
+  rstate_1.setJointGroupVelocities(planning_group_, default_joint_velocity);
+  rstate_2.setJointGroupVelocities(planning_group_, default_joint_velocity);
 
   double default_joint_acceleration[6] = {0.0, 0.0, 0.0, 0.0, 0.0, 0.0};
-  rstate_1->setJointGroupAccelerations(planning_group_, default_joint_acceleration);
+  rstate_1.setJointGroupAccelerations(planning_group_, default_joint_acceleration);
   // Ensure that the joint accelerations of both robot states are different
   default_joint_acceleration[1]  = default_joint_acceleration[1] + 10.0;
-  rstate_2->setJointGroupAccelerations(planning_group_, default_joint_acceleration);
+  rstate_2.setJointGroupAccelerations(planning_group_, default_joint_acceleration);
 
   double epsilon {0.0001};
   EXPECT_FALSE( pilz::isRobotStateEqual(rstate_1, rstate_2, planning_group_, epsilon) );
@@ -947,11 +947,11 @@ TEST_P(TrajectoryFunctionsTestFlangeAndGripper, testIsRobotStateEqualAcceleratio
  */
 TEST_P(TrajectoryFunctionsTestFlangeAndGripper, testIsRobotStateStationaryVelocityUnequal)
 {
-  robot_state::RobotStatePtr rstate_1 = std::make_shared<robot_state::RobotState>(robot_model_);
+  robot_state::RobotState rstate_1 = robot_state::RobotState(robot_model_);
 
   // Ensure that the joint velocities are NOT zero
   double default_joint_velocity [6] = {1.0, 0.0, 0.0, 0.0, 0.0, 0.0};
-  rstate_1->setJointGroupVelocities(planning_group_, default_joint_velocity);
+  rstate_1.setJointGroupVelocities(planning_group_, default_joint_velocity);
 
   double epsilon {0.0001};
   EXPECT_FALSE( pilz::isRobotStateStationary(rstate_1, planning_group_, epsilon) );
@@ -970,15 +970,15 @@ TEST_P(TrajectoryFunctionsTestFlangeAndGripper, testIsRobotStateStationaryVeloci
  */
 TEST_P(TrajectoryFunctionsTestFlangeAndGripper, testIsRobotStateStationaryAccelerationUnequal)
 {
-  robot_state::RobotStatePtr rstate_1 = std::make_shared<robot_state::RobotState>(robot_model_);
+  robot_state::RobotState rstate_1 = robot_state::RobotState(robot_model_);
 
   // Ensure that the joint velocities are zero
   double default_joint_velocity [6] = {0.0, 0.0, 0.0, 0.0, 0.0, 0.0};
-  rstate_1->setJointGroupVelocities(planning_group_, default_joint_velocity);
+  rstate_1.setJointGroupVelocities(planning_group_, default_joint_velocity);
 
   // Ensure that the joint acceleration are NOT zero
   double default_joint_acceleration [6] = {1.0, 0.0, 0.0, 0.0, 0.0, 0.0};
-  rstate_1->setJointGroupAccelerations(planning_group_, default_joint_acceleration);
+  rstate_1.setJointGroupAccelerations(planning_group_, default_joint_acceleration);
 
   double epsilon {0.0001};
   EXPECT_FALSE( pilz::isRobotStateStationary(rstate_1, planning_group_, epsilon) );


### PR DESCRIPTION
* refactor existing code
* use plain C++ objects instead of creating shared pointers
* avoids interal warning facing the user for every blend request