### PR TITLE
Allowing failure on non shadow-fixed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,9 +20,15 @@ env:
   global:
     - AFTER_SCRIPT='apt list --installed | grep "^ros-"'
     - CCACHE_DIR=$HOME/.ccache
+    - ROS_DISTRO="melodic" 
+    - CATKIN_LINT=true
+    - CATKIN_LINT_ARGS='--strict'
   matrix:
-    - ROS_DISTRO="melodic" ROS_REPO=ros CATKIN_LINT=true CATKIN_LINT_ARGS='--strict'
-    - ROS_DISTRO="melodic" ROS_REPO=ros-shadow-fixed CATKIN_LINT=true CATKIN_LINT_ARGS='--strict'
+    - ROS_REPO=ros
+    - ROS_REPO=ros-shadow-fixed
+matrix:
+  allow_failures:
+    - env: ROS_REPO=ros
 install:
   - git clone --depth=1 https://github.com/ros-industrial/industrial_ci.git .industrial_ci
 script:


### PR DESCRIPTION
With this change, the build only fails if the ros-shadow-fixed job fails.