### PR TITLE
Replace tf by tf2 in pilz_robot_programming

### DIFF
--- a/pilz_robot_programming/package.xml
+++ b/pilz_robot_programming/package.xml
@@ -14,25 +14,27 @@
   <license>LGPLv3</license>
 
   <run_depend>moveit_commander</run_depend>
-  <run_depend>tf</run_depend>
-  <run_depend>rospy</run_depend>
+  <run_depend>tf2_ros</run_depend>
+  <run_depend>tf2_geometry_msgs</run_depend>
+  <run_depend>tf_conversions</run_depend>
+  <run_depend>pilz_msgs</run_depend>
   <run_depend>pilz_trajectory_generation</run_depend>
   <run_depend>pilz_msgs</run_depend>
   <run_depend>python-psutil</run_depend>
-  <run_depend>tf_conversions</run_depend>
+  <run_depend>rospy</run_depend>
 
   <buildtool_depend>catkin</buildtool_depend>
 
-  <build_depend>rospy</build_depend>
   <build_depend>roslint</build_depend>
+  <build_depend>rospy</build_depend>
 
   <test_depend>python-docopt</test_depend>
-  <test_depend>rostest</test_depend>
-  <test_depend>prbt_moveit_config</test_depend>
-  <test_depend>prbt_pg70_support</test_depend>
   <test_depend>pilz_industrial_motion_testutils</test_depend>
   <test_depend>python-coverage</test_depend>
   <test_depend>python-mock</test_depend>
+  <test_depend>prbt_moveit_config</test_depend>
+  <test_depend>prbt_pg70_support</test_depend>
+  <test_depend>rostest</test_depend>
   <test_depend>rosunit</test_depend>
 
 </package>

--- a/pilz_robot_programming/src/pilz_robot_programming/commands.py
+++ b/pilz_robot_programming/src/pilz_robot_programming/commands.py
@@ -18,7 +18,8 @@
 from __future__ import absolute_import
 
 import rospy
-from tf import transformations
+import tf2_geometry_msgs  # for buffer.transform() to eat a geometry_msgs.Pose directly
+from tf_conversions import transformations
 from geometry_msgs.msg import Quaternion, Pose
 from geometry_msgs.msg import PoseStamped
 from pilz_msgs.msg import MoveGroupSequenceGoal, MotionSequenceItem
@@ -679,7 +680,7 @@ def _to_robot_reference(robot, pose_frame, goal_pose_custom_ref):
     stamped = PoseStamped()
     stamped.header.frame_id = pose_frame
     stamped.pose = goal_pose_custom_ref
-    return robot.tf_listener_.transformPose(robot_ref, stamped).pose
+    return robot.tf_buffer_.transform(stamped, robot_ref).pose
 
 
 def _to_ori_constraint(pose, reference_frame, link_name, orientation_tolerance=_DEFAULT_ORIENTATION_TOLERANCE):

--- a/pilz_robot_programming/src/pilz_robot_programming/robot.py
+++ b/pilz_robot_programming/src/pilz_robot_programming/robot.py
@@ -27,7 +27,8 @@ from moveit_msgs.msg import MoveItErrorCodes
 import rospy
 from std_msgs.msg import Header
 from std_srvs.srv import Trigger
-import tf
+import tf2_ros
+import tf2_geometry_msgs  # for buffer.transform() to eat a geometry_msgs.Pose directly
 
 from pilz_msgs.msg import MoveGroupSequenceAction, IsBrakeTestRequiredResult
 from pilz_msgs.srv import GetSpeedOverride, IsBrakeTestRequired, BrakeTest, BrakeTestResponse
@@ -119,7 +120,8 @@ class Robot(object):
 
         # tf listener is necessary for pose transformation
         # when using custom reference frames.
-        self.tf_listener_ = tf.TransformListener()
+        self.tf_buffer_ = tf2_ros.Buffer()
+        self.tf_listener_ = tf2_ros.TransformListener(self.tf_buffer_)
 
         self._move_lock = threading.Lock()
 
@@ -190,14 +192,11 @@ class Robot(object):
         """
 
         try:
-            self.tf_listener_.waitForTransform(
-                target_link, base, rospy.Time(), rospy.Duration(5, 0))
-            orientation_ = Quaternion(0, 0, 0, 1)
-            stamped = PoseStamped(header=Header(frame_id=target_link),
-                                  pose=Pose(orientation=orientation_))
-            current_pose = self.tf_listener_.transformPose(base, stamped).pose
+            zero_pose = PoseStamped(header=Header(frame_id=target_link),
+                                    pose=Pose(orientation=Quaternion(w=1.0)))
+            current_pose = self.tf_buffer_.transform(zero_pose, base, rospy.Duration(5, 0)).pose
             return current_pose
-        except tf.Exception as e:
+        except tf2_ros.LookupException as e:
             rospy.logerr(e.message)
             raise RobotCurrentStateError(e.message)
 


### PR DESCRIPTION
Implements #163.

See tutorials like
http://wiki.ros.org/tf2/Tutorials/Writing%20a%20tf2%20broadcaster%20%28Python%29

Note: This is just a first step; the tf dependency is still pulled in by `quaternion_from_euler` and friends. C++ test refactoring in pilz_trajectory_generation is also left for a future PR.