### PR TITLE
catkin and boost includes as System

### DIFF
--- a/pilz_trajectory_generation/CMakeLists.txt
+++ b/pilz_trajectory_generation/CMakeLists.txt
@@ -60,8 +60,13 @@ catkin_package(
 
 include_directories(
   include
-  ${catkin_INCLUDE_DIRS}
+)
+
+# To avoid Warnings from clang-tidy declare system
+include_directories(
+  SYSTEM
   ${Boost_INCLUDE_DIRS}
+  ${catkin_INCLUDE_DIRS}
 )
 
 ## Declare a C++ library


### PR DESCRIPTION
Declaring catkin and boost includes as system hides them from clang tidy