### PR TITLE
Replace outdated BARRIER2() by BARRIER()

### DIFF
--- a/pilz_trajectory_generation/test/integrationtest_sequence_action_capability.cpp
+++ b/pilz_trajectory_generation/test/integrationtest_sequence_action_capability.cpp
@@ -377,7 +377,7 @@ TEST_F(IntegrationTestSequenceAction, TestActionServerCallbacks)
                std::bind(&IntegrationTestSequenceAction::feedback_callback, this, ph::_1));
 
   // wait for the ecpected events
-  BARRIER2({GOAL_SUCCEEDED_EVENT, SERVER_IDLE_EVENT});
+  BARRIER({GOAL_SUCCEEDED_EVENT, SERVER_IDLE_EVENT});
 }
 
 /**


### PR DESCRIPTION
fixes build error