### PR TITLE
Remove version from clang-tidy

### DIFF
--- a/pilz_extensions/CMakeLists.txt
+++ b/pilz_extensions/CMakeLists.txt
@@ -13,13 +13,13 @@ find_package(catkin REQUIRED COMPONENTS
 ################
   find_program(
     CLANG_TIDY_EXE
-    NAMES "clang-tidy-6.0"
+    NAMES "clang-tidy"
     DOC "Path to clang-tidy executable"
     )
   if(NOT CLANG_TIDY_EXE)
-    message(FATAL_ERROR "clang-tidy-6.0 not found.")
+    message(FATAL_ERROR "clang-tidy not found.")
   else()
-    message(STATUS "clang-tidy-6.0 found: ${CLANG_TIDY_EXE}")
+    message(STATUS "clang-tidy found: ${CLANG_TIDY_EXE}")
     set(CMAKE_CXX_CLANG_TIDY "${CLANG_TIDY_EXE}")
   endif()
 

--- a/pilz_industrial_motion_testutils/CMakeLists.txt
+++ b/pilz_industrial_motion_testutils/CMakeLists.txt
@@ -28,13 +28,13 @@ catkin_python_setup()
 ################
 find_program(
   CLANG_TIDY_EXE
-  NAMES "clang-tidy-6.0"
+  NAMES "clang-tidy"
   DOC "Path to clang-tidy executable"
   )
 if(NOT CLANG_TIDY_EXE)
-  message(FATAL_ERROR "clang-tidy-6.0 not found.")
+  message(FATAL_ERROR "clang-tidy not found.")
 else()
-  message(STATUS "clang-tidy-6.0 found: ${CLANG_TIDY_EXE}")
+  message(STATUS "clang-tidy found: ${CLANG_TIDY_EXE}")
   set(CMAKE_CXX_CLANG_TIDY "${CLANG_TIDY_EXE}")
 endif()
 

--- a/pilz_trajectory_generation/CMakeLists.txt
+++ b/pilz_trajectory_generation/CMakeLists.txt
@@ -34,13 +34,13 @@ find_package(Boost REQUIRED COMPONENTS )
 ################
 find_program(
   CLANG_TIDY_EXE
-  NAMES "clang-tidy-6.0"
+  NAMES "clang-tidy"
   DOC "Path to clang-tidy executable"
   )
 if(NOT CLANG_TIDY_EXE)
-  message(FATAL_ERROR "clang-tidy-6.0 not found.")
+  message(FATAL_ERROR "clang-tidy not found.")
 else()
-  message(STATUS "clang-tidy-6.0 found: ${CLANG_TIDY_EXE}")
+  message(STATUS "clang-tidy found: ${CLANG_TIDY_EXE}")
   set(CMAKE_CXX_CLANG_TIDY "${CLANG_TIDY_EXE}")
 endif()
 


### PR DESCRIPTION
Hopefully fixes broken builds:

http://build.ros.org/view/Mbin_dsv8_dSv8/job/Mbin_dsv8_dSv8__pilz_industrial_motion_testutils__debian_stretch_arm64__binary/11

http://build.ros.org/view/Mbin_dsv8_dSv8/job/Mbin_dsv8_dSv8__pilz_extensions__debian_stretch_arm64__binary/13

Search Log for "CMake Error"

Similiar to https://github.com/PilzDE/pilz_robots/pull/219