### PR TITLE
Better clang-tidy integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,9 +20,10 @@ env:
   global:
     - AFTER_SCRIPT='apt list --installed | grep "^ros-"'
     - CCACHE_DIR=$HOME/.ccache
-    - ROS_DISTRO="melodic" 
+    - ROS_DISTRO="melodic"
     - CATKIN_LINT=true
     - CATKIN_LINT_ARGS='--strict'
+    - ADDITIONAL_DEBS="clang-tidy libclang-dev"
   matrix:
     - ROS_REPO=ros
     - ROS_REPO=ros-shadow-fixed

--- a/pilz_extensions/CMakeLists.txt
+++ b/pilz_extensions/CMakeLists.txt
@@ -11,6 +11,7 @@ find_package(catkin REQUIRED COMPONENTS
 ################
 ## Clang tidy ##
 ################
+if(CATKIN_ENABLE_CLANG_TIDY)
   find_program(
     CLANG_TIDY_EXE
     NAMES "clang-tidy"
@@ -22,6 +23,7 @@ find_package(catkin REQUIRED COMPONENTS
     message(STATUS "clang-tidy found: ${CLANG_TIDY_EXE}")
     set(CMAKE_CXX_CLANG_TIDY "${CLANG_TIDY_EXE}")
   endif()
+endif()
 
 ###################################
 ## catkin specific configuration ##

--- a/pilz_extensions/package.xml
+++ b/pilz_extensions/package.xml
@@ -18,7 +18,6 @@
   <url type="bugtracker">https://github.com/PilzDE/pilz_industrial_motion/issues</url>
   <url type="repository">https://github.com/PilzDE/pilz_industrial_motion</url>
 
-  <build_depend>clang-tidy</build_depend>
   <build_depend>roscpp</build_depend>
 
   <depend>joint_limits_interface</depend>

--- a/pilz_industrial_motion_testutils/CMakeLists.txt
+++ b/pilz_industrial_motion_testutils/CMakeLists.txt
@@ -26,16 +26,18 @@ catkin_python_setup()
 ################
 ## Clang tidy ##
 ################
-find_program(
-  CLANG_TIDY_EXE
-  NAMES "clang-tidy"
-  DOC "Path to clang-tidy executable"
-  )
-if(NOT CLANG_TIDY_EXE)
-  message(FATAL_ERROR "clang-tidy not found.")
-else()
-  message(STATUS "clang-tidy found: ${CLANG_TIDY_EXE}")
-  set(CMAKE_CXX_CLANG_TIDY "${CLANG_TIDY_EXE}")
+if(CATKIN_ENABLE_CLANG_TIDY)
+  find_program(
+    CLANG_TIDY_EXE
+    NAMES "clang-tidy"
+    DOC "Path to clang-tidy executable"
+    )
+  if(NOT CLANG_TIDY_EXE)
+    message(FATAL_ERROR "clang-tidy not found.")
+  else()
+    message(STATUS "clang-tidy found: ${CLANG_TIDY_EXE}")
+    set(CMAKE_CXX_CLANG_TIDY "${CLANG_TIDY_EXE}")
+  endif()
 endif()
 
 ###################################

--- a/pilz_industrial_motion_testutils/package.xml
+++ b/pilz_industrial_motion_testutils/package.xml
@@ -16,8 +16,7 @@
   <url type="repository">https://github.com/PilzDE/pilz_industrial_motion</url>
 
   <build_depend>eigen_conversions</build_depend>
-  <build_depend>clang-tidy</build_depend>
-  <build_depend>moveit_core</build_depend>
+    <build_depend>moveit_core</build_depend>
   <build_depend>moveit_msgs</build_depend>
   <build_depend>pilz_msgs</build_depend>
 

--- a/pilz_industrial_motion_testutils/package.xml
+++ b/pilz_industrial_motion_testutils/package.xml
@@ -16,7 +16,7 @@
   <url type="repository">https://github.com/PilzDE/pilz_industrial_motion</url>
 
   <build_depend>eigen_conversions</build_depend>
-    <build_depend>moveit_core</build_depend>
+  <build_depend>moveit_core</build_depend>
   <build_depend>moveit_msgs</build_depend>
   <build_depend>pilz_msgs</build_depend>
 

--- a/pilz_trajectory_generation/CMakeLists.txt
+++ b/pilz_trajectory_generation/CMakeLists.txt
@@ -32,16 +32,18 @@ find_package(Boost REQUIRED COMPONENTS )
 ################
 ## Clang tidy ##
 ################
-find_program(
-  CLANG_TIDY_EXE
-  NAMES "clang-tidy"
-  DOC "Path to clang-tidy executable"
-  )
-if(NOT CLANG_TIDY_EXE)
-  message(FATAL_ERROR "clang-tidy not found.")
-else()
-  message(STATUS "clang-tidy found: ${CLANG_TIDY_EXE}")
-  set(CMAKE_CXX_CLANG_TIDY "${CLANG_TIDY_EXE}")
+if(CATKIN_ENABLE_CLANG_TIDY)
+  find_program(
+    CLANG_TIDY_EXE
+    NAMES "clang-tidy"
+    DOC "Path to clang-tidy executable"
+    )
+  if(NOT CLANG_TIDY_EXE)
+    message(FATAL_ERROR "clang-tidy not found.")
+  else()
+    message(STATUS "clang-tidy found: ${CLANG_TIDY_EXE}")
+    set(CMAKE_CXX_CLANG_TIDY "${CLANG_TIDY_EXE}")
+  endif()
 endif()
 
 ###################################

--- a/pilz_trajectory_generation/package.xml
+++ b/pilz_trajectory_generation/package.xml
@@ -17,8 +17,6 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
-  <build_depend>clang-tidy</build_depend>
-
   <depend>orocos_kdl</depend>
   <depend>roscpp</depend>
   <depend>moveit_msgs</depend>


### PR DESCRIPTION
* Add debs for clang-tidy to travis configuration file
* Enable clang-tidy via cmake flag

Same as https://github.com/PilzDE/pilz_robots/pull/239

I suggest using this instead of https://github.com/PilzDE/pilz_industrial_motion/pull/202 since this would require users only to have clang-tidy and libclang-dev if the want to open a PR. Also it does not require the buildfarm to install libclang-dev.