### PR TITLE
Add missing dependency on prbt_hardware_support

### DIFF
--- a/pilz_robot_programming/CMakeLists.txt
+++ b/pilz_robot_programming/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(pilz_robot_programming)
 
-find_package(catkin REQUIRED COMPONENTS roslint rospy)
+find_package(catkin REQUIRED COMPONENTS roslint rospy prbt_hardware_support)
 
 catkin_package()
 

--- a/pilz_robot_programming/package.xml
+++ b/pilz_robot_programming/package.xml
@@ -20,11 +20,13 @@
   <run_depend>pilz_msgs</run_depend>
   <run_depend>python-psutil</run_depend>
   <run_depend>tf_conversions</run_depend>
+  <run_depend>prbt_hardware_support</run_depend>
 
   <buildtool_depend>catkin</buildtool_depend>
 
   <build_depend>rospy</build_depend>
   <build_depend>roslint</build_depend>
+  <build_depend>prbt_hardware_support</build_depend>
 
   <test_depend>python-docopt</test_depend>
   <test_depend>rostest</test_depend>


### PR DESCRIPTION
According to https://docs.ros.org/melodic/api/catkin/html/howto/format1/index.html

Should fix errors on buildfarm: http://build.ros.org/job/Mdoc__pilz_industrial_motion__ubuntu_bionic_amd64/12/console
```
05:31:30 Traceback (most recent call last):
05:31:30   File "/usr/lib/python2.7/dist-packages/sphinx/ext/autodoc.py", line 658, in import_object
05:31:30     __import__(self.modname)
05:31:30   File "/tmp/ws/install_isolated/lib/python2.7/dist-packages/pilz_robot_programming/__init__.py", line 22, in <module>
05:31:30     from .exceptions import *
05:31:30   File "/tmp/ws/install_isolated/lib/python2.7/dist-packages/pilz_robot_programming/exceptions.py", line 18, in <module>
05:31:30     from prbt_hardware_support.msg import BrakeTestErrorCodes
05:31:30 ImportError: No module named prbt_hardware_support.msg
```