### PR TITLE
Add client for speed_override to python API

### DIFF
--- a/pilz_robot_programming/CHANGELOG.rst
+++ b/pilz_robot_programming/CHANGELOG.rst
@@ -4,7 +4,7 @@ Changelog for package pilz_robot_programming
 
 Forthcoming
 -----------
-* Add speed override as readable property
+* Override speed of motions
 * Contributors: Pilz GmbH and Co. KG
 
 0.4.7 (2019-09-10)

--- a/pilz_robot_programming/CHANGELOG.rst
+++ b/pilz_robot_programming/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package pilz_robot_programming
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+Forthcoming
+-----------
+* Add speed override as readable property
+* Contributors: Pilz GmbH and Co. KG
+
 0.4.7 (2019-09-10)
 ------------------
 

--- a/pilz_robot_programming/Readme.rst
+++ b/pilz_robot_programming/Readme.rst
@@ -7,7 +7,7 @@ stopped.
 All examples are given for a PRBT robot but the API is general enough to be used with any robot that
 has a MoveIt! configuration, it merely requires the availability of the following services:
 
-- ``/get_operation_mode``
+- ``/get_speed_override``
 - ``/prbt/brake_test_required``
 - ``/prbt/execute_braketest``
 
@@ -76,7 +76,7 @@ Speed-override
 ^^^^^^^^^^^^^^
 
 The speed override depends on the operation mode of the robot system,
-see prbt_hardware_support_.
+see prbt_hardware_support_, it can not be set via the Python API.
 
 .. _prbt_hardware_support: https://github.com/PilzDE/pilz_robots/tree/melodic-devel/prbt_hardware_support
 

--- a/pilz_robot_programming/Readme.rst
+++ b/pilz_robot_programming/Readme.rst
@@ -67,17 +67,11 @@ robot behaves as expected/intended. In case the versions do not match, an except
 :note:
     For the API version check only the major version number is relevant.
 
-Speed-override
-^^^^^^^^^^^^^^
-
-The speed override depends on the operation mode of the robot system,
-see prbt_hardware_support_, it can not be set via the Python API.
+:note:
+    In general the speed of all motions depends on the operation mode of the robot system.
+    For more information see prbt_hardware_support_.
 
 .. _prbt_hardware_support: https://github.com/PilzDE/pilz_robots/tree/melodic-devel/prbt_hardware_support
-
-.. code-block:: python
-
-    print(r.speed_override)
 
 Move
 ^^^^

--- a/pilz_robot_programming/Readme.rst
+++ b/pilz_robot_programming/Readme.rst
@@ -5,13 +5,8 @@ to execute command sequences (called :py:class:`.Sequence`). On top of that, the
 stopped.
 
 All examples are given for a PRBT robot but the API is general enough to be used with any robot that
-has a MoveIt! configuration, it merely requires the availability of the following services:
-
-- ``/get_speed_override``
-- ``/prbt/brake_test_required``
-- ``/prbt/execute_braketest``
-
-In particular, this enables the execution of brake tests. More information can be found here_.
+has a MoveIt! configuration, it merely requires the availability of the service ``/get_speed_override``
+for obtaining the speed override of the robot system.
 
 .. _here: https://github.com/PilzDE/pilz_robots/tree/melodic-devel/prbt_hardware_support
 

--- a/pilz_robot_programming/Readme.rst
+++ b/pilz_robot_programming/Readme.rst
@@ -5,7 +5,15 @@ to execute command sequences (called :py:class:`.Sequence`). On top of that, the
 stopped.
 
 All examples are given for a PRBT robot but the API is general enough to be used with any robot that
-has a MoveIt! configuration.
+has a MoveIt! configuration, it merely requires the availability of the following services:
+
+- ``/get_operation_mode``
+- ``/prbt/brake_test_required``
+- ``/prbt/execute_braketest``
+
+In particular, this enables the execution of brake tests. More information can be found here_.
+
+.. _here: https://github.com/PilzDE/pilz_robots/tree/melodic-devel/prbt_hardware_support
 
 The robot API has some similarity to the ``moveit_commander`` package but differs in its specialization for
 classical industrial robot commands to be executed by the ``pilz_command_planner`` MoveIt! plugin. The
@@ -63,6 +71,18 @@ robot behaves as expected/intended. In case the versions do not match, an except
 
 :note:
     For the API version check only the major version number is relevant.
+
+Speed-override
+^^^^^^^^^^^^^^
+
+The speed override depends on the operation mode of the robot system,
+see prbt_hardware_support_.
+
+.. _prbt_hardware_support: https://github.com/PilzDE/pilz_robots/tree/melodic-devel/prbt_hardware_support
+
+.. code-block:: python
+
+    print(r.speed_override)
 
 Move
 ^^^^

--- a/pilz_robot_programming/examples/demo_program.py
+++ b/pilz_robot_programming/examples/demo_program.py
@@ -28,6 +28,9 @@ def start_program():
 
     r = Robot(__REQUIRED_API_VERSION__)
 
+    # Print global speed override
+    print(r.speed_override)
+
     # Simple ptp movement
     r.move(Ptp(goal=[0, 0.5, 0.5, 0, 0, 0], vel_scale=0.4))
 

--- a/pilz_robot_programming/examples/demo_program.py
+++ b/pilz_robot_programming/examples/demo_program.py
@@ -28,9 +28,6 @@ def start_program():
 
     r = Robot(__REQUIRED_API_VERSION__)
 
-    # Print global speed override
-    print(r.speed_override)
-
     # Simple ptp movement
     r.move(Ptp(goal=[0, 0.5, 0.5, 0, 0, 0], vel_scale=0.4))
 

--- a/pilz_robot_programming/src/pilz_robot_programming/commands.py
+++ b/pilz_robot_programming/src/pilz_robot_programming/commands.py
@@ -208,8 +208,8 @@ class _BaseCmd(_AbstractCmd):
         # Set general info
         req.planner_id = self._planner_id
         req.group_name = self._planning_group
-        req.max_velocity_scaling_factor = self._vel_scale * robot.global_motion_factor
-        req.max_acceleration_scaling_factor = self._acc_scale * self._calc_acc_scale(robot.global_motion_factor)
+        req.max_velocity_scaling_factor = self._vel_scale * robot.speed_override
+        req.max_acceleration_scaling_factor = self._acc_scale * self._calc_acc_scale(robot.speed_override)
         req.allowed_planning_time = 1.0
 
         # Set an empty diff as start_state => the current state is used by the planner
@@ -607,8 +607,8 @@ class Gripper(_BaseCmd):
         # Set general info
         req.planner_id = "PTP"
         req.group_name = self._planning_group
-        req.max_velocity_scaling_factor = self._vel_scale * robot.global_motion_factor
-        req.max_acceleration_scaling_factor = self._acc_scale * robot.global_motion_factor
+        req.max_velocity_scaling_factor = self._vel_scale * robot.speed_override
+        req.max_acceleration_scaling_factor = self._acc_scale * robot.speed_override
         req.allowed_planning_time = 1.0
         # Set an empty diff as start_state => the current state is used by the planner
         req.start_state.is_diff = True

--- a/pilz_robot_programming/src/pilz_robot_programming/commands.py
+++ b/pilz_robot_programming/src/pilz_robot_programming/commands.py
@@ -607,8 +607,8 @@ class Gripper(_BaseCmd):
         # Set general info
         req.planner_id = "PTP"
         req.group_name = self._planning_group
-        req.max_velocity_scaling_factor = self._vel_scale * robot._speed_override
-        req.max_acceleration_scaling_factor = self._acc_scale * robot._speed_override
+        req.max_velocity_scaling_factor = self._vel_scale
+        req.max_acceleration_scaling_factor = self._acc_scale
         req.allowed_planning_time = 1.0
         # Set an empty diff as start_state => the current state is used by the planner
         req.start_state.is_diff = True

--- a/pilz_robot_programming/src/pilz_robot_programming/commands.py
+++ b/pilz_robot_programming/src/pilz_robot_programming/commands.py
@@ -208,8 +208,8 @@ class _BaseCmd(_AbstractCmd):
         # Set general info
         req.planner_id = self._planner_id
         req.group_name = self._planning_group
-        req.max_velocity_scaling_factor = self._vel_scale * robot.speed_override
-        req.max_acceleration_scaling_factor = self._acc_scale * self._calc_acc_scale(robot.speed_override)
+        req.max_velocity_scaling_factor = self._vel_scale * robot._speed_override
+        req.max_acceleration_scaling_factor = self._acc_scale * self._calc_acc_scale(robot._speed_override)
         req.allowed_planning_time = 1.0
 
         # Set an empty diff as start_state => the current state is used by the planner
@@ -607,8 +607,8 @@ class Gripper(_BaseCmd):
         # Set general info
         req.planner_id = "PTP"
         req.group_name = self._planning_group
-        req.max_velocity_scaling_factor = self._vel_scale * robot.speed_override
-        req.max_acceleration_scaling_factor = self._acc_scale * robot.speed_override
+        req.max_velocity_scaling_factor = self._vel_scale * robot._speed_override
+        req.max_acceleration_scaling_factor = self._acc_scale * robot._speed_override
         req.allowed_planning_time = 1.0
         # Set an empty diff as start_state => the current state is used by the planner
         req.start_state.is_diff = True

--- a/pilz_robot_programming/src/pilz_robot_programming/robot.py
+++ b/pilz_robot_programming/src/pilz_robot_programming/robot.py
@@ -162,7 +162,7 @@ class Robot(object):
     def speed_override(self):
         """ Returns the currently active speed override
 
-        Both velocity and acceleration scaling are factorized. The command itself remains untouched.
+        Both velocity and acceleration scaling of a command are factorized during :py:meth:`move`. The command itself remains untouched.
         """
         res = self._get_speed_override_srv()
 

--- a/pilz_robot_programming/src/pilz_robot_programming/robot.py
+++ b/pilz_robot_programming/src/pilz_robot_programming/robot.py
@@ -126,8 +126,6 @@ class Robot(object):
         # manage the move control request
         self._move_ctrl_sm = _MoveControlStateMachine()
 
-        self._get_speed_override_srv = rospy.ServiceProxy(Robot._GET_SPEED_OVERRIDE_SRV, GetSpeedOverride)
-
         self._single_instance_flag = False
 
         self._check_version(version)
@@ -519,6 +517,12 @@ class Robot(object):
             Robot._RESUME_TOPIC_NAME, Trigger, self._resume_service_callback)
         self._stop_service = rospy.Service(
             Robot._STOP_TOPIC_NAME, Trigger, self._stop_service_callback)
+
+        # Connect to speed override service
+        rospy.loginfo("Waiting for connection to service " + self._GET_SPEED_OVERRIDE_SRV + "...")
+        rospy.wait_for_service(self._GET_SPEED_OVERRIDE_SRV, self._SERVICE_WAIT_TIMEOUT_S)
+        rospy.loginfo("Connection to service " + self._GET_SPEED_OVERRIDE_SRV + " estabilshed")
+        self._get_speed_override_srv = rospy.ServiceProxy(self._GET_SPEED_OVERRIDE_SRV, GetSpeedOverride)
 
     def _release(self):
         rospy.logdebug("Release called")

--- a/pilz_robot_programming/src/pilz_robot_programming/robot.py
+++ b/pilz_robot_programming/src/pilz_robot_programming/robot.py
@@ -159,7 +159,7 @@ class Robot(object):
         self.__robot_commander = robot_commander
 
     @property
-    def speed_override(self):
+    def _speed_override(self):
         """ Returns the currently active speed override
 
         Both velocity and acceleration scaling of a command are factorized during :py:meth:`move`. The command itself remains untouched.

--- a/pilz_robot_programming/src/pilz_robot_programming/robot.py
+++ b/pilz_robot_programming/src/pilz_robot_programming/robot.py
@@ -160,7 +160,8 @@ class Robot(object):
     def _speed_override(self):
         """ Returns the currently active speed override
 
-        Both velocity and acceleration scaling of a command are factorized during :py:meth:`move`. The command itself remains untouched.
+        Both velocity and acceleration scaling of a command are factorized during :py:meth:`move`.
+        The command itself remains untouched.
         """
         res = self._get_speed_override_srv()
 

--- a/pilz_robot_programming/test/integrationtests/integrationtest_self_collision.test
+++ b/pilz_robot_programming/test/integrationtests/integrationtest_self_collision.test
@@ -38,6 +38,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
     <arg name="pipeline" value="pilz_command_planner" />
   </include>
 
+  <node name="fake_speed_override_node" pkg="prbt_hardware_support" type="fake_speed_override_node"/>
+
   <!-- test node -->
   <test test-name="integrationtest_self_collision" pkg="pilz_robot_programming"
     type="integrationtest_self_collision.py" time-limit="300"

--- a/pilz_robot_programming/test/integrationtests/tst_api_brake_test.test
+++ b/pilz_robot_programming/test/integrationtests/tst_api_brake_test.test
@@ -36,6 +36,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
         <arg name="pipeline" value="pilz_command_planner" />
     </include>
 
+    <node name="fake_speed_override_node" pkg="prbt_hardware_support" type="fake_speed_override_node"/>
+
     <!-- test node -->
     <test test-name="test_api_brake_test" pkg="pilz_robot_programming"
           type="tst_api_brake_test.py" time-limit="300"

--- a/pilz_robot_programming/test/integrationtests/tst_api_cmd_conversion.py
+++ b/pilz_robot_programming/test/integrationtests/tst_api_cmd_conversion.py
@@ -20,6 +20,7 @@ import numpy as np
 import tf
 import tf_conversions.posemath as pm
 from geometry_msgs.msg import Point
+from tst_api_utils import setOverrideParam
 
 
 from pilz_robot_programming.robot import *
@@ -134,6 +135,7 @@ class TestAPICmdConversion(unittest.TestCase):
                                req_position.z)
 
     def setUp(self):
+        setOverrideParam(1.0)
         rospy.loginfo("Loading Robot...")
         self.robot = Robot(API_VERSION)
         rospy.loginfo("Loading Robot done")
@@ -374,16 +376,16 @@ class TestAPICmdConversion(unittest.TestCase):
         # +++++++++++++++++++++++
         ptp = Ptp(goal=self.test_data.get_joints("PTPJointValid", PLANNING_GROUP_NAME), vel_scale=EXP_VEL_SCALE,
                   relative=True)
-        self.robot.global_motion_factor = 0.1
+        setOverrideParam(0.1)
         req = ptp._cmd_to_request(self.robot)
         self.assertIsNotNone(req)
 
         # +++++++++++++++++++++++
         rospy.loginfo("Step 2")
         # +++++++++++++++++++++++
-        self.assertEquals(self.robot.global_motion_factor*self.robot.global_motion_factor*EXP_VEL_SCALE*EXP_VEL_SCALE,
+        self.assertEquals(self.robot.speed_override*self.robot.speed_override*EXP_VEL_SCALE*EXP_VEL_SCALE,
                           req.max_acceleration_scaling_factor)
-        self.assertEquals(self.robot.global_motion_factor*EXP_VEL_SCALE, req.max_velocity_scaling_factor)
+        self.assertEquals(self.robot.speed_override*EXP_VEL_SCALE, req.max_velocity_scaling_factor)
 
     def test_lin_cmd_convert_pose(self):
         """ Check that conversion to MotionPlanRequest works correctly.
@@ -547,15 +549,15 @@ class TestAPICmdConversion(unittest.TestCase):
         # +++++++++++++++++++++++
         lin = Lin(goal=self.test_data.get_joints("LINPose1", PLANNING_GROUP_NAME), vel_scale=EXP_VEL_SCALE,
                   relative=True)
-        self.robot.global_motion_factor = 0.1
+        setOverrideParam(0.1)
         req = lin._cmd_to_request(self.robot)
         self.assertIsNotNone(req)
 
         # +++++++++++++++++++++++
         rospy.loginfo("Step 2")
         # +++++++++++++++++++++++
-        self.assertEquals(self.robot.global_motion_factor*EXP_VEL_SCALE, req.max_acceleration_scaling_factor)
-        self.assertEquals(self.robot.global_motion_factor*EXP_VEL_SCALE, req.max_velocity_scaling_factor)
+        self.assertEquals(self.robot.speed_override*EXP_VEL_SCALE, req.max_acceleration_scaling_factor)
+        self.assertEquals(self.robot.speed_override*EXP_VEL_SCALE, req.max_velocity_scaling_factor)
 
     def test_circ_cmd_convert_center(self):
         """ Check that conversion to MotionPlanRequest works correctly.
@@ -696,15 +698,15 @@ class TestAPICmdConversion(unittest.TestCase):
         exp_help_pose = self.test_data.get_pose("CIRCCenterPose", PLANNING_GROUP_NAME)
 
         circ = Circ(goal=exp_goal_pose, center=exp_help_pose.position, vel_scale=EXP_VEL_SCALE)
-        self.robot.global_motion_factor = 0.1
+        setOverrideParam(0.1)
         req = circ._cmd_to_request(self.robot)
         self.assertIsNotNone(req)
 
         # +++++++++++++++++++++++
         rospy.loginfo("Step 2")
         # +++++++++++++++++++++++
-        self.assertEquals(self.robot.global_motion_factor*EXP_VEL_SCALE, req.max_acceleration_scaling_factor)
-        self.assertEquals(self.robot.global_motion_factor*EXP_VEL_SCALE, req.max_velocity_scaling_factor)
+        self.assertEquals(self.robot.speed_override*EXP_VEL_SCALE, req.max_acceleration_scaling_factor)
+        self.assertEquals(self.robot.speed_override*EXP_VEL_SCALE, req.max_velocity_scaling_factor)
 
     def test_get_sequence_request(self):
         """ Test the _get_sequence_request function of Sequence command works correctly.
@@ -770,7 +772,7 @@ class TestAPICmdConversion(unittest.TestCase):
         self._analyze_request_pose(TARGET_LINK_NAME, exp_circ_goal, circ_req)
         self._analyze_request_circ_help_point("center", exp_circ_center, circ_req)
 
-    def test_get_sequence_request_global_motion_factor(self):
+    def test_get_sequence_request_speed_override(self):
         """ Test that setting the global motion factor on sequence works correctly
 
             Test sequence:
@@ -805,7 +807,7 @@ class TestAPICmdConversion(unittest.TestCase):
 
         # 2
         fac = 0.2
-        self.robot.global_motion_factor = fac
+        setOverrideParam(fac)
 
         # 3
         seq_action_goal = seq._get_sequence_request(self.robot)

--- a/pilz_robot_programming/test/integrationtests/tst_api_cmd_conversion.py
+++ b/pilz_robot_programming/test/integrationtests/tst_api_cmd_conversion.py
@@ -383,9 +383,9 @@ class TestAPICmdConversion(unittest.TestCase):
         # +++++++++++++++++++++++
         rospy.loginfo("Step 2")
         # +++++++++++++++++++++++
-        self.assertEquals(self.robot.speed_override*self.robot.speed_override*EXP_VEL_SCALE*EXP_VEL_SCALE,
+        self.assertEquals(self.robot._speed_override*self.robot._speed_override*EXP_VEL_SCALE*EXP_VEL_SCALE,
                           req.max_acceleration_scaling_factor)
-        self.assertEquals(self.robot.speed_override*EXP_VEL_SCALE, req.max_velocity_scaling_factor)
+        self.assertEquals(self.robot._speed_override*EXP_VEL_SCALE, req.max_velocity_scaling_factor)
 
     def test_lin_cmd_convert_pose(self):
         """ Check that conversion to MotionPlanRequest works correctly.
@@ -556,8 +556,8 @@ class TestAPICmdConversion(unittest.TestCase):
         # +++++++++++++++++++++++
         rospy.loginfo("Step 2")
         # +++++++++++++++++++++++
-        self.assertEquals(self.robot.speed_override*EXP_VEL_SCALE, req.max_acceleration_scaling_factor)
-        self.assertEquals(self.robot.speed_override*EXP_VEL_SCALE, req.max_velocity_scaling_factor)
+        self.assertEquals(self.robot._speed_override*EXP_VEL_SCALE, req.max_acceleration_scaling_factor)
+        self.assertEquals(self.robot._speed_override*EXP_VEL_SCALE, req.max_velocity_scaling_factor)
 
     def test_circ_cmd_convert_center(self):
         """ Check that conversion to MotionPlanRequest works correctly.
@@ -705,8 +705,8 @@ class TestAPICmdConversion(unittest.TestCase):
         # +++++++++++++++++++++++
         rospy.loginfo("Step 2")
         # +++++++++++++++++++++++
-        self.assertEquals(self.robot.speed_override*EXP_VEL_SCALE, req.max_acceleration_scaling_factor)
-        self.assertEquals(self.robot.speed_override*EXP_VEL_SCALE, req.max_velocity_scaling_factor)
+        self.assertEquals(self.robot._speed_override*EXP_VEL_SCALE, req.max_acceleration_scaling_factor)
+        self.assertEquals(self.robot._speed_override*EXP_VEL_SCALE, req.max_velocity_scaling_factor)
 
     def test_get_sequence_request(self):
         """ Test the _get_sequence_request function of Sequence command works correctly.

--- a/pilz_robot_programming/test/integrationtests/tst_api_cmd_conversion.test
+++ b/pilz_robot_programming/test/integrationtests/tst_api_cmd_conversion.test
@@ -37,6 +37,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
     <arg name="pipeline" value="pilz_command_planner" />
   </include>
 
+  <node name="fake_speed_override_node" pkg="prbt_hardware_support" type="fake_speed_override_node"/>
+
   <!-- test node -->
   <test test-name="api_command_conversion" pkg="pilz_robot_programming"
     type="tst_api_cmd_conversion.py" time-limit="300"

--- a/pilz_robot_programming/test/integrationtests/tst_api_cmd_conversion_with_gripper.test
+++ b/pilz_robot_programming/test/integrationtests/tst_api_cmd_conversion_with_gripper.test
@@ -39,6 +39,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
     <arg name="pipeline" value="pilz_command_planner" />
   </include>
 
+  <node name="fake_speed_override_node" pkg="prbt_hardware_support" type="fake_speed_override_node"/>
+
   <!-- test node -->
   <test test-name="api_command_conversion" pkg="pilz_robot_programming"
     type="tst_api_cmd_conversion.py" time-limit="300"

--- a/pilz_robot_programming/test/integrationtests/tst_api_execution_error.test
+++ b/pilz_robot_programming/test/integrationtests/tst_api_execution_error.test
@@ -35,6 +35,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
   </node>
 
   <node name="moveit_mock" pkg="pilz_robot_programming" type="moveit_mock.py"/>
+  <node name="fake_speed_override_node" pkg="prbt_hardware_support" type="fake_speed_override_node"/>
 
   <!-- test node -->
   <test test-name="test_api_execution_error" pkg="pilz_robot_programming"

--- a/pilz_robot_programming/test/integrationtests/tst_api_execution_stop.test
+++ b/pilz_robot_programming/test/integrationtests/tst_api_execution_stop.test
@@ -39,6 +39,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
     <arg name="pipeline" value="pilz_command_planner" />
   </include>
 
+  <node name="fake_speed_override_node" pkg="prbt_hardware_support" type="fake_speed_override_node"/>
+
   <!-- test node -->
   <test test-name="test_api_execution_stop" pkg="pilz_robot_programming"
     type="tst_api_execution_stop.py" time-limit="500"

--- a/pilz_robot_programming/test/integrationtests/tst_api_execution_stop_with_gripper.test
+++ b/pilz_robot_programming/test/integrationtests/tst_api_execution_stop_with_gripper.test
@@ -41,6 +41,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
     <arg name="pipeline" value="pilz_command_planner" />
   </include>
 
+  <node name="fake_speed_override_node" pkg="prbt_hardware_support" type="fake_speed_override_node"/>
+
   <!-- test node -->
   <test test-name="test_api_execution_stop" pkg="pilz_robot_programming"
     type="tst_api_execution_stop.py" time-limit="300"

--- a/pilz_robot_programming/test/integrationtests/tst_api_gripper.py
+++ b/pilz_robot_programming/test/integrationtests/tst_api_gripper.py
@@ -21,6 +21,7 @@ from pilz_industrial_motion_testutils.xml_testdata_loader import *
 from pilz_robot_programming.commands import *
 from pilz_industrial_motion_testutils.integration_test_utils import *
 from pilz_industrial_motion_testutils.robot_motion_observer import RobotMotionObserver
+from tst_api_utils import setOverrideParam
 
 _TEST_DATA_FILE_NAME = RosPack().get_path("pilz_industrial_motion_testutils") + "/test_data/testdata_deprecated.xml"
 API_VERSION = "1"
@@ -94,6 +95,24 @@ class TestAPIGripper(unittest.TestCase):
         self.assertEqual("PTP", req.planner_id)
         self.assertEqual(0.0, req.goal_constraints[0].joint_constraints[0].position)
         self.assertEqual(0.1, req.max_velocity_scaling_factor)
+
+    def test_gripper_cmd_convert_ignore_speed_override(self):
+        """ Test the gripper convert function ignores the speed override.
+
+            Test sequence:
+                1. Call gripper convert function with a valid floating point goal and set a SpeedOverride
+
+            Test Results:
+                1. The max_velocity_scaling_factor and max_acceleration_scaling_factor is not changed.
+        """
+
+        gripper_cmd = Gripper(goal=0.02, vel_scale=0.1, acc_scale=0.2)
+        req = gripper_cmd._cmd_to_request(self.robot)
+        setOverrideParam(0.1)
+
+        # gripper command is internal a ptp command
+        self.assertEqual(0.1, req.max_velocity_scaling_factor)
+        self.assertEqual(0.2, req.max_acceleration_scaling_factor)
 
     def test_gripper_execution(self):
         """ Test execution of valid gripper command works successfully.

--- a/pilz_robot_programming/test/integrationtests/tst_api_gripper.test
+++ b/pilz_robot_programming/test/integrationtests/tst_api_gripper.test
@@ -39,6 +39,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
     <arg name="pipeline" value="pilz_command_planner" />
   </include>
 
+  <node name="fake_speed_override_node" pkg="prbt_hardware_support" type="fake_speed_override_node"/>
+
   <!-- test node -->
   <test test-name="api_gripper" pkg="pilz_robot_programming"
     type="tst_api_gripper.py" time-limit="300"

--- a/pilz_robot_programming/test/integrationtests/tst_api_instantiation.test
+++ b/pilz_robot_programming/test/integrationtests/tst_api_instantiation.test
@@ -37,6 +37,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
     <arg name="pipeline" value="pilz_command_planner" />
   </include>
 
+  <node name="fake_speed_override_node" pkg="prbt_hardware_support" type="fake_speed_override_node"/>
+
   <!-- test node -->
   <test test-name="test_api_instantiation" pkg="pilz_robot_programming"
         type="tst_api_instantiation.py"

--- a/pilz_robot_programming/test/integrationtests/tst_api_pause.test
+++ b/pilz_robot_programming/test/integrationtests/tst_api_pause.test
@@ -39,6 +39,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
     <arg name="pipeline" value="pilz_command_planner" />
   </include>
 
+  <node name="fake_speed_override_node" pkg="prbt_hardware_support" type="fake_speed_override_node"/>
+
   <!-- test node -->
   <test test-name="test_api_pause" pkg="pilz_robot_programming"
     type="tst_api_pause.py" time-limit="300"

--- a/pilz_robot_programming/test/integrationtests/tst_api_pause_concurrency.test
+++ b/pilz_robot_programming/test/integrationtests/tst_api_pause_concurrency.test
@@ -39,6 +39,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
     <arg name="pipeline" value="pilz_command_planner" />
   </include>
 
+  <node name="fake_speed_override_node" pkg="prbt_hardware_support" type="fake_speed_override_node"/>
+
   <!-- test node -->
   <test test-name="test_api_pause_concurrency" pkg="pilz_robot_programming"
     type="tst_api_pause_concurrency.py" time-limit="300"

--- a/pilz_robot_programming/test/integrationtests/tst_api_program_termination.test
+++ b/pilz_robot_programming/test/integrationtests/tst_api_program_termination.test
@@ -42,6 +42,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
     <arg name="pipeline" value="pilz_command_planner" />
   </include>
 
+  <node name="fake_speed_override_node" pkg="prbt_hardware_support" type="fake_speed_override_node"/>
+
   <!-- test node -->
   <test test-name="test_api_program_termination" pkg="pilz_robot_programming"
     type="tst_api_program_termination.py" launch-prefix="$(arg pythontest_launch_prefix)" />

--- a/pilz_robot_programming/test/integrationtests/tst_api_utility_functions.test
+++ b/pilz_robot_programming/test/integrationtests/tst_api_utility_functions.test
@@ -37,6 +37,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
     <arg name="pipeline" value="pilz_command_planner" />
   </include>
 
+  <node name="fake_speed_override_node" pkg="prbt_hardware_support" type="fake_speed_override_node"/>
+
   <!-- test node -->
   <test test-name="test_api_utility_functions" pkg="pilz_robot_programming"
     type="tst_api_utility_functions.py" time-limit="300"

--- a/pilz_robot_programming/test/integrationtests/tst_api_utils.py
+++ b/pilz_robot_programming/test/integrationtests/tst_api_utils.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python
+# Copyright (c) 2019 Pilz GmbH & Co. KG
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import rospy
+
+from dynamic_reconfigure.srv import Reconfigure, ReconfigureRequest
+from dynamic_reconfigure.msg import DoubleParameter
+
+def setOverrideParam(speed_override):
+  set_dynamic_parameter = rospy.ServiceProxy('/fake_speed_override_node/set_parameters', Reconfigure)
+  rec = ReconfigureRequest();
+  double_param = DoubleParameter();
+  double_param.name = "speed_override"
+  double_param.value = speed_override
+  rec.config.doubles.append(double_param)
+  set_dynamic_parameter(rec)

--- a/pilz_robot_programming/test/integrationtests/tst_api_utils.py
+++ b/pilz_robot_programming/test/integrationtests/tst_api_utils.py
@@ -19,11 +19,12 @@ import rospy
 from dynamic_reconfigure.srv import Reconfigure, ReconfigureRequest
 from dynamic_reconfigure.msg import DoubleParameter
 
+
 def setOverrideParam(speed_override):
-  set_dynamic_parameter = rospy.ServiceProxy('/fake_speed_override_node/set_parameters', Reconfigure)
-  rec = ReconfigureRequest();
-  double_param = DoubleParameter();
-  double_param.name = "speed_override"
-  double_param.value = speed_override
-  rec.config.doubles.append(double_param)
-  set_dynamic_parameter(rec)
+    set_dynamic_parameter = rospy.ServiceProxy('/fake_speed_override_node/set_parameters', Reconfigure)
+    rec = ReconfigureRequest()
+    double_param = DoubleParameter()
+    double_param.name = "speed_override"
+    double_param.value = speed_override
+    rec.config.doubles.append(double_param)
+    set_dynamic_parameter(rec)

--- a/pilz_robot_programming/test/integrationtests/tst_joint_position_limits.test
+++ b/pilz_robot_programming/test/integrationtests/tst_joint_position_limits.test
@@ -39,6 +39,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
     <arg name="pipeline" value="pilz_command_planner" />
   </include>
 
+  <node name="fake_speed_override_node" pkg="prbt_hardware_support" type="fake_speed_override_node"/>
+
   <!-- test node -->
   <test test-name="test_joint_position_limits" pkg="pilz_robot_programming"
     type="tst_joint_position_limits.py" launch-prefix="$(arg pythontest_launch_prefix)" time-limit="120.0"/>

--- a/pilz_robot_programming/test/integrationtests/tst_robot_functions.py
+++ b/pilz_robot_programming/test/integrationtests/tst_robot_functions.py
@@ -42,7 +42,7 @@ class TestGlobalMotionFactor(unittest.TestCase):
 
     def testSettingOverride(self):
         setOverrideParam(0.3)
-        self.assertEqual(self.robot.speed_override, 0.3)
+        self.assertEqual(self.robot._speed_override, 0.3)
 
     def testInvariantMoveOnCommand(self):
         """ Test that the command itself remains untouched to the speed override"""

--- a/pilz_robot_programming/test/integrationtests/tst_robot_functions.py
+++ b/pilz_robot_programming/test/integrationtests/tst_robot_functions.py
@@ -27,8 +27,9 @@ API_VERSION = "1"
 PKG = 'pilz_robot_programming'
 roslib.load_manifest(PKG)  # This line is not needed with Catkin.
 
-class TestGlobalMotionFactor(unittest.TestCase):
-    """ Checks the basic behaviour of the global motion factor.
+
+class TestSpeedOverride(unittest.TestCase):
+    """ Checks the basic behaviour of the speed override.
         More in-depth checks are done withing the tst_api_cmd_conversion.py
     """
     def setUp(self):
@@ -56,4 +57,4 @@ if __name__ == '__main__':
     import rostest
     rospy.init_node('tst_robot_functions')
     rostest.rosrun('pilz_robot_programming',
-                   'tst_robot_functions', TestGlobalMotionFactor)
+                   'tst_robot_functions', TestSpeedOverride)

--- a/pilz_robot_programming/test/integrationtests/tst_robot_functions.py
+++ b/pilz_robot_programming/test/integrationtests/tst_robot_functions.py
@@ -20,12 +20,12 @@ import sys
 from rospkg import RosPack
 from pilz_robot_programming.robot import *
 from pilz_robot_programming.commands import Ptp
+from tst_api_utils import setOverrideParam
 import roslib
 
 API_VERSION = "1"
 PKG = 'pilz_robot_programming'
 roslib.load_manifest(PKG)  # This line is not needed with Catkin.
-
 
 class TestGlobalMotionFactor(unittest.TestCase):
     """ Checks the basic behaviour of the global motion factor.
@@ -41,26 +41,16 @@ class TestGlobalMotionFactor(unittest.TestCase):
             self.robot = None
 
     def testSettingOverride(self):
-        self.robot.global_motion_factor = 0.3
-        self.assertEqual(self.robot.global_motion_factor, 0.3)
+        setOverrideParam(0.3)
+        self.assertEqual(self.robot.speed_override, 0.3)
 
     def testInvariantMoveOnCommand(self):
         """ Test that the command itself remains untouched to the speed override"""
-
-        self.robot.global_motion_factor = 0.3
+        setOverrideParam(0.3)
         ptp = Ptp(goal=[0, 0.5, 0.5, 0, 0, 0], vel_scale=0.3, acc_scale=0.4)
         self.robot.move(ptp)
         self.assertEqual(ptp._vel_scale, 0.3)
         self.assertEqual(ptp._acc_scale, 0.4)
-
-    def testSettingOverrideNegative(self):
-        with self.assertRaises(ValueError):
-            self.robot.global_motion_factor = -1.0
-
-    def testSettingOverrideTooLarge(self):
-        with self.assertRaises(ValueError):
-            self.robot.global_motion_factor = 1.1
-
 
 if __name__ == '__main__':
     import rostest

--- a/pilz_robot_programming/test/integrationtests/tst_robot_functions.test
+++ b/pilz_robot_programming/test/integrationtests/tst_robot_functions.test
@@ -37,6 +37,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
     <arg name="pipeline" value="pilz_command_planner" />
   </include>
 
+  <node name="fake_speed_override_node" pkg="prbt_hardware_support" type="fake_speed_override_node"/>
+
   <!-- test node -->
   <test test-name="tst_robot_functions" pkg="pilz_robot_programming"
     type="tst_robot_functions.py" time-limit="300"

--- a/pilz_robot_programming/test/integrationtests/tst_sequence_with_gripper.test
+++ b/pilz_robot_programming/test/integrationtests/tst_sequence_with_gripper.test
@@ -39,6 +39,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
     <arg name="pipeline" value="pilz_command_planner" />
   </include>
 
+  <node name="fake_speed_override_node" pkg="prbt_hardware_support" type="fake_speed_override_node"/>
+
   <!-- test node -->
   <test test-name="test_sequence_with_gripper" pkg="pilz_robot_programming"
     type="tst_sequence_with_gripper.py" time-limit="300"


### PR DESCRIPTION
In combination with [PR #257](https://github.com/PilzDE/pilz_robots/pull/257) this PR aims to reduce the velocity for every motion (here: only in PythonAPI motions!) in such a way that the max speeds for each frame is not violated.

* Rename global_motion_factor -> speed_override
* Add client which obtains the factor via service