### PR TITLE
add missing library to linking stage

### DIFF
--- a/pilz_trajectory_generation/CMakeLists.txt
+++ b/pilz_trajectory_generation/CMakeLists.txt
@@ -234,6 +234,7 @@ if(CATKIN_ENABLE_TESTING)
       src/cartesian_limits_aggregator.cpp
       src/planning_context_loader.cpp
       src/plan_components_builder.cpp
+      src/pilz_command_planner.cpp
   )
 
   target_link_libraries(${PROJECT_NAME}_test
@@ -429,7 +430,7 @@ ${catkin_LIBRARIES} ${PROJECT_NAME}_test)
   )
 
   target_link_libraries(unittest_pilz_command_planner
-    ${catkin_LIBRARIES})
+    ${catkin_LIBRARIES} ${PROJECT_NAME}_test)
 
   # JointLimitsAggregator Unit Test
   add_rostest_gtest(unittest_joint_limits_aggregator


### PR DESCRIPTION
To build the tests correctly, add `pilz_command_planner.cpp` to the corresponding unit test (`catkin config --install && catkin build --make-args test` otherwise spits undefined reference errors).