### PR TITLE
Feature/general speed override srv

### DIFF
--- a/pilz_msgs/CHANGELOG.rst
+++ b/pilz_msgs/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package pilz_msgs
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+Forthcoming
+-----------
+* Add srv definition for speed override
+* Contributors: Pilz GmbH and Co. KG
+
 0.4.7 (2019-09-10)
 ------------------
 

--- a/pilz_msgs/CMakeLists.txt
+++ b/pilz_msgs/CMakeLists.txt
@@ -2,29 +2,30 @@ cmake_minimum_required(VERSION 2.8.3)
 project(pilz_msgs)
 
 find_package(catkin REQUIRED COMPONENTS
-    message_generation
-    moveit_msgs)
+  message_generation
+  moveit_msgs)
 
-## Generate messages in the 'msg' folder
- add_message_files(
-   FILES
-   MotionSequenceItem.msg
-   MotionSequenceRequest.msg
- )
+# Generate messages in the 'msg' folder
+add_message_files(
+  FILES
+  MotionSequenceItem.msg
+  MotionSequenceRequest.msg
+)
 
- #Generate services in the 'srv' folder
- add_service_files(
-   FILES
-   GetMotionSequence.srv
- )
+#Generate services in the 'srv' folder
+add_service_files(
+  FILES
+  GetMotionSequence.srv
+  GetSpeedOverride.srv
+)
 
 # Generate actions in the 'action' folder
- add_action_files(
-   FILES
-   MoveGroupSequence.action
- )
+add_action_files(
+  FILES
+  MoveGroupSequence.action
+)
 
-## Generate added messages and services with any dependencies listed here
+# Generate added messages and services with any dependencies listed here
 generate_messages(DEPENDENCIES moveit_msgs)
 
 catkin_package(CATKIN_DEPENDS message_runtime moveit_msgs)

--- a/pilz_msgs/srv/GetSpeedOverride.srv
+++ b/pilz_msgs/srv/GetSpeedOverride.srv
@@ -1,0 +1,17 @@
+#
+# Copyright (c) 2019 Pilz GmbH & Co. KG
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+float64 speed_override # between [0...1]


### PR DESCRIPTION
The speed override is a general concept needed by the Python API. See #212.

The definition in prbt_hardware_support should be removed:
https://github.com/PilzDE/pilz_robots/blob/melodic-devel/prbt_hardware_support/srv/GetSpeedOverride.srv