### PR TITLE
Rename ROS_REPO ros -> main in travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,11 +25,11 @@ env:
     - CATKIN_LINT_ARGS='--strict'
     - ADDITIONAL_DEBS="clang-tidy libclang-dev"
   matrix:
-    - ROS_REPO=ros
+    - ROS_REPO=main
     - ROS_REPO=testing
 matrix:
   allow_failures:
-    - env: ROS_REPO=ros
+    - env: ROS_REPO=main
 install:
   - git clone --depth=1 --branch master https://github.com/ros-industrial/industrial_ci.git .industrial_ci
 script:


### PR DESCRIPTION
I think it is more consistent to either use `ros` & `ros_shadow_fixed` or `main` & `testing`.