### PR TITLE
Review cmake test targets

### DIFF
--- a/pilz_trajectory_generation/CMakeLists.txt
+++ b/pilz_trajectory_generation/CMakeLists.txt
@@ -214,9 +214,9 @@ if(CATKIN_ENABLE_TESTING)
     APPEND_COVERAGE_COMPILER_FLAGS()
   endif()
 
-#########################
-####Integration Tests####
-#########################
+  #########################
+  ####Integration Tests####
+  #########################
 
   set(${PROJECT_NAME}_integrationtests
     sequence_capability
@@ -226,96 +226,115 @@ if(CATKIN_ENABLE_TESTING)
     planning_context_loader_circ
   )
 
-# Planning Integration tests
-add_rostest_gmock(integrationtest_sequence_action_capability
-  test/integrationtest_sequence_action_capability.test
-  test/integrationtest_sequence_action_capability.cpp
-)
+  # Planning Integration tests
+  add_rostest_gmock(integrationtest_sequence_action_capability
+    test/integrationtest_sequence_action_capability.test
+    test/integrationtest_sequence_action_capability.cpp
+  )
 
-target_link_libraries(integrationtest_sequence_action_capability
-   ${catkin_LIBRARIES} ${pilz_testutils_LIBRARIES} ${${PROJECT_NAME}_integrationtests})
+  target_link_libraries(integrationtest_sequence_action_capability
+    ${catkin_LIBRARIES}
+    ${pilz_testutils_LIBRARIES}
+    ${${PROJECT_NAME}_integrationtests}
+  )
 
-add_rostest(test/integrationtest_sequence_action_capability_with_gripper.test
-  DEPENDENCIES integrationtest_sequence_action_capability
-)
+  add_rostest(test/integrationtest_sequence_action_capability_with_gripper.test
+    DEPENDENCIES integrationtest_sequence_action_capability
+  )
 
-# Tests with other robots only for kinetic (for now)
+  # Tests with other robots only for kinetic (for now)
 
-#add_rostest(test/integrationtest_sequence_action_capability_abb_irb2400.test
-#  DEPENDENCIES integrationtest_sequence_action_capability
-#)
+  #add_rostest(test/integrationtest_sequence_action_capability_abb_irb2400.test
+  #  DEPENDENCIES integrationtest_sequence_action_capability
+  #)
 
-#add_rostest(test/integrationtest_sequence_action_capability_frankaemika_panda.test
-#  DEPENDENCIES integrationtest_sequence_action_capability
-#)
+  #add_rostest(test/integrationtest_sequence_action_capability_frankaemika_panda.test
+  #  DEPENDENCIES integrationtest_sequence_action_capability
+  #)
 
-add_rostest_gtest(integrationtest_sequence_service_capability
-  test/integrationtest_sequence_service_capability.test
-  test/integrationtest_sequence_service_capability.cpp
-)
-target_link_libraries(integrationtest_sequence_service_capability
-  ${catkin_LIBRARIES} ${${PROJECT_NAME}_integrationtests})
+  add_rostest_gtest(integrationtest_sequence_service_capability
+    test/integrationtest_sequence_service_capability.test
+    test/integrationtest_sequence_service_capability.cpp
+  )
 
-# Tests with other robots only for kinetic (for now)
+  target_link_libraries(integrationtest_sequence_service_capability
+    ${catkin_LIBRARIES}
+    ${${PROJECT_NAME}_integrationtests}
+  )
 
-#add_rostest(test/integrationtest_sequence_service_capability_frankaemika_panda.test
-#  DEPENDENCIES integrationtest_sequence_service_capability )
+  # Tests with other robots only for kinetic (for now)
 
-#add_rostest(test/integrationtest_sequence_service_capability_abb_irb2400.test
-#  DEPENDENCIES integrationtest_sequence_service_capability )
+  #add_rostest(test/integrationtest_sequence_service_capability_frankaemika_panda.test
+  #  DEPENDENCIES integrationtest_sequence_service_capability )
 
-add_rostest(test/integrationtest_sequence_service_capability_with_gripper.test
-  DEPENDENCIES integrationtest_sequence_service_capability
-)
+  #add_rostest(test/integrationtest_sequence_service_capability_abb_irb2400.test
+  #  DEPENDENCIES integrationtest_sequence_service_capability )
 
-# Planning Integration tests
-add_rostest_gtest(integrationtest_command_planning
-  test/integrationtest_command_planning.test
-  test/integrationtest_command_planning.cpp
-  test/test_utils.cpp
-)
-target_link_libraries(integrationtest_command_planning
-   ${catkin_LIBRARIES} ${${PROJECT_NAME}_integrationtests})
+  add_rostest(test/integrationtest_sequence_service_capability_with_gripper.test
+    DEPENDENCIES integrationtest_sequence_service_capability
+  )
 
-add_rostest(test/integrationtest_command_planning_with_gripper.test
-  DEPENDENCIES integrationtest_command_planning )
+  # Planning Integration tests
+  add_rostest_gtest(integrationtest_command_planning
+    test/integrationtest_command_planning.test
+    test/integrationtest_command_planning.cpp
+    test/test_utils.cpp
+  )
 
-# Tests with other robots only for kinetic (for now)
+  target_link_libraries(integrationtest_command_planning
+    ${catkin_LIBRARIES}
+    ${${PROJECT_NAME}_integrationtests}
+  )
 
-#add_rostest(test/integrationtest_command_planning_abb_irb2400.test
-#  DEPENDENCIES integrationtest_command_planning )
+  add_rostest(test/integrationtest_command_planning_with_gripper.test
+    DEPENDENCIES integrationtest_command_planning
+  )
 
-#add_rostest(test/integrationtest_command_planning_frankaemika_panda.test
-#  DEPENDENCIES integrationtest_command_planning )
+  # Tests with other robots only for kinetic (for now)
 
-# Blending Integration tests
-add_rostest_gtest(integrationtest_command_list_manager
-  test/integrationtest_command_list_manager.test
-  test/integrationtest_command_list_manager.cpp
-  test/test_utils.cpp
-)
-target_link_libraries(integrationtest_command_list_manager
-${catkin_LIBRARIES} ${${PROJECT_NAME}_integrationtests})
+  #add_rostest(test/integrationtest_command_planning_abb_irb2400.test
+  #  DEPENDENCIES integrationtest_command_planning )
 
-add_rostest_gtest(integrationtest_get_solver_tip_frame
-  test/integrationtest_get_solver_tip_frame.test
-  test/integrationtest_get_solver_tip_frame.cpp
-)
-target_link_libraries(integrationtest_get_solver_tip_frame
-${catkin_LIBRARIES} ${${PROJECT_NAME}_integrationtests})
+  #add_rostest(test/integrationtest_command_planning_frankaemika_panda.test
+  #  DEPENDENCIES integrationtest_command_planning )
 
-add_rostest_gtest(integrationtest_plan_components_builder
-  test/integrationtest_plan_components_builder.test
-  test/integrationtest_plan_components_builder.cpp
-)
-target_link_libraries(integrationtest_plan_components_builder
-${catkin_LIBRARIES} ${${PROJECT_NAME}_integrationtests})
+  # Blending Integration tests
+  add_rostest_gtest(integrationtest_command_list_manager
+    test/integrationtest_command_list_manager.test
+    test/integrationtest_command_list_manager.cpp
+    test/test_utils.cpp
+  )
+
+  target_link_libraries(integrationtest_command_list_manager
+    ${catkin_LIBRARIES}
+    ${${PROJECT_NAME}_integrationtests}
+  )
+
+  add_rostest_gtest(integrationtest_get_solver_tip_frame
+    test/integrationtest_get_solver_tip_frame.test
+    test/integrationtest_get_solver_tip_frame.cpp
+  )
+
+  target_link_libraries(integrationtest_get_solver_tip_frame
+    ${catkin_LIBRARIES}
+    ${${PROJECT_NAME}_integrationtests}
+  )
+
+  add_rostest_gtest(integrationtest_plan_components_builder
+    test/integrationtest_plan_components_builder.test
+    test/integrationtest_plan_components_builder.cpp
+  )
+
+  target_link_libraries(integrationtest_plan_components_builder
+    ${catkin_LIBRARIES}
+    ${${PROJECT_NAME}_integrationtests}
+  )
 
 
 
-##################
-####Unit Tests####
-##################
+  ##################
+  ####Unit Tests####
+  ##################
 
   add_library(${PROJECT_NAME}_testutils
     test/test_utils.cpp
@@ -331,23 +350,32 @@ ${catkin_LIBRARIES} ${${PROJECT_NAME}_integrationtests})
 
   ## Add gtest based cpp test target and link libraries
   catkin_add_gtest(unittest_pilz_command_planner_direct
-                   test/unittest_pilz_command_planner_direct.cpp
-                   src/planning_context_loader_ptp.cpp)
+    test/unittest_pilz_command_planner_direct.cpp
+    src/planning_context_loader_ptp.cpp
+  )
+
   target_link_libraries(unittest_pilz_command_planner_direct
-    ${catkin_LIBRARIES} ${PROJECT_NAME}_testutils)
+    ${catkin_LIBRARIES}
+    ${PROJECT_NAME}_testutils
+  )
 
   ## Add gtest based cpp test target and link libraries
   catkin_add_gtest(unittest_velocity_profile_atrap
-                   test/unittest_velocity_profile_atrap.cpp
-                   src/velocity_profile_atrap.cpp)
-  target_link_libraries(unittest_velocity_profile_atrap
-    ${catkin_LIBRARIES})
+    test/unittest_velocity_profile_atrap.cpp
+    src/velocity_profile_atrap.cpp
+  )
+
+  target_link_libraries(unittest_velocity_profile_atrap ${catkin_LIBRARIES})
 
   catkin_add_gtest(unittest_trajectory_generator
-                   test/unittest_trajectory_generator.cpp
-                   src/trajectory_generator.cpp)
+    test/unittest_trajectory_generator.cpp
+    src/trajectory_generator.cpp
+  )
+
   target_link_libraries(unittest_trajectory_generator
-    ${catkin_LIBRARIES} ${PROJECT_NAME})
+    ${catkin_LIBRARIES}
+    ${PROJECT_NAME}
+  )
 
   # Trajectory Generator Unit Test
   add_rostest_gtest(unittest_trajectory_functions
@@ -356,8 +384,9 @@ ${catkin_LIBRARIES} ${${PROJECT_NAME}_integrationtests})
   )
 
   target_link_libraries(unittest_trajectory_functions
-    ${catkin_LIBRARIES} ${PROJECT_NAME}_testutils)
-
+    ${catkin_LIBRARIES}
+    ${PROJECT_NAME}_testutils
+  )
 
   # unittest for trajectory blender transition window
   add_rostest_gtest(unittest_trajectory_blender_transition_window
@@ -367,7 +396,9 @@ ${catkin_LIBRARIES} ${${PROJECT_NAME}_integrationtests})
   )
 
   target_link_libraries(unittest_trajectory_blender_transition_window
-    ${catkin_LIBRARIES} ${PROJECT_NAME}_testutils)
+    ${catkin_LIBRARIES}
+    ${PROJECT_NAME}_testutils
+  )
 
   # trajectory generator Unit Test
   add_rostest_gtest(unittest_trajectory_generator_common
@@ -376,7 +407,9 @@ ${catkin_LIBRARIES} ${${PROJECT_NAME}_integrationtests})
   )
 
   target_link_libraries(unittest_trajectory_generator_common
-      ${catkin_LIBRARIES} ${PROJECT_NAME}_testutils)
+    ${catkin_LIBRARIES}
+    ${PROJECT_NAME}_testutils
+  )
 
 
   # trajectory generator circ Unit Test
@@ -386,7 +419,9 @@ ${catkin_LIBRARIES} ${${PROJECT_NAME}_integrationtests})
   )
 
   target_link_libraries(unittest_trajectory_generator_circ
-    ${catkin_LIBRARIES} ${PROJECT_NAME}_testutils)
+    ${catkin_LIBRARIES}
+    ${PROJECT_NAME}_testutils
+  )
 
   # trajectory generator lin Unit Test
   add_rostest_gtest(unittest_trajectory_generator_lin
@@ -395,7 +430,9 @@ ${catkin_LIBRARIES} ${${PROJECT_NAME}_integrationtests})
   )
 
   target_link_libraries(unittest_trajectory_generator_lin
-      ${catkin_LIBRARIES} ${PROJECT_NAME}_testutils)
+    ${catkin_LIBRARIES}
+    ${PROJECT_NAME}_testutils
+  )
 
   # trajectory generator ptp Unit Test
   add_rostest_gtest(unittest_trajectory_generator_ptp
@@ -404,7 +441,9 @@ ${catkin_LIBRARIES} ${${PROJECT_NAME}_integrationtests})
   )
 
   target_link_libraries(unittest_trajectory_generator_ptp
-    ${catkin_LIBRARIES} ${PROJECT_NAME}_testutils)
+    ${catkin_LIBRARIES}
+    ${PROJECT_NAME}_testutils
+  )
 
   # Command Planner Unit Test
   add_rostest_gtest(unittest_pilz_command_planner
@@ -413,7 +452,9 @@ ${catkin_LIBRARIES} ${${PROJECT_NAME}_integrationtests})
   )
 
   target_link_libraries(unittest_pilz_command_planner
-    ${catkin_LIBRARIES} ${PROJECT_NAME})
+    ${catkin_LIBRARIES}
+    ${PROJECT_NAME}
+  )
 
   # JointLimitsAggregator Unit Test
   add_rostest_gtest(unittest_joint_limits_aggregator
@@ -422,7 +463,9 @@ ${catkin_LIBRARIES} ${${PROJECT_NAME}_integrationtests})
   )
 
   target_link_libraries(unittest_joint_limits_aggregator
-      ${catkin_LIBRARIES} ${PROJECT_NAME})
+    ${catkin_LIBRARIES}
+    ${PROJECT_NAME}
+  )
 
   # JointLimitsContainer Unit Test
   catkin_add_gtest(unittest_joint_limits_container
@@ -430,7 +473,9 @@ ${catkin_LIBRARIES} ${${PROJECT_NAME}_integrationtests})
   )
 
   target_link_libraries(unittest_joint_limits_container
-    ${catkin_LIBRARIES} ${PROJECT_NAME})
+    ${catkin_LIBRARIES}
+    ${PROJECT_NAME}
+  )
 
   # JointLimitsValidator Unit Test
   catkin_add_gtest(unittest_joint_limits_validator
@@ -438,7 +483,9 @@ ${catkin_LIBRARIES} ${${PROJECT_NAME}_integrationtests})
   )
 
   target_link_libraries(unittest_joint_limits_validator
-     ${catkin_LIBRARIES} ${PROJECT_NAME})
+    ${catkin_LIBRARIES}
+    ${PROJECT_NAME}
+  )
 
    # Cartesian Limits Aggregator Unit Test
   add_rostest_gtest(unittest_cartesian_limits_aggregator
@@ -447,7 +494,9 @@ ${catkin_LIBRARIES} ${${PROJECT_NAME}_integrationtests})
   )
 
   target_link_libraries(unittest_cartesian_limits_aggregator
-    ${catkin_LIBRARIES} ${PROJECT_NAME})
+    ${catkin_LIBRARIES}
+    ${PROJECT_NAME}
+  )
 
   # PlanningContextLoaderPTP Unit Test
   add_rostest_gtest(unittest_planning_context_loaders
@@ -456,7 +505,9 @@ ${catkin_LIBRARIES} ${${PROJECT_NAME}_integrationtests})
   )
 
   target_link_libraries(unittest_planning_context_loaders
-    ${catkin_LIBRARIES} ${PROJECT_NAME}_testutils)
+    ${catkin_LIBRARIES}
+    ${PROJECT_NAME}_testutils
+  )
 
   # PlanningContext Unit Test (Typed test)
   add_rostest_gtest(unittest_planning_context
@@ -465,18 +516,19 @@ ${catkin_LIBRARIES} ${${PROJECT_NAME}_integrationtests})
     src/planning_context_loader_circ.cpp
     src/planning_context_loader_lin.cpp
     src/planning_context_loader_ptp.cpp
-    )
+  )
 
   target_link_libraries(unittest_planning_context
-     ${catkin_LIBRARIES} ${PROJECT_NAME}_testutils)
+    ${catkin_LIBRARIES}
+    ${PROJECT_NAME}_testutils
+  )
 
   # GetTipFrames Unit Test
   catkin_add_gmock(unittest_get_solver_tip_frame
     test/unittest_get_solver_tip_frame.cpp
   )
 
-  target_link_libraries(unittest_get_solver_tip_frame
-    ${catkin_LIBRARIES})
+  target_link_libraries(unittest_get_solver_tip_frame ${catkin_LIBRARIES})
 
   # to run: catkin_make -DENABLE_COVERAGE_TESTING=ON package_name_coverage
   if(ENABLE_COVERAGE_TESTING)

--- a/pilz_trajectory_generation/CMakeLists.txt
+++ b/pilz_trajectory_generation/CMakeLists.txt
@@ -218,7 +218,7 @@ if(CATKIN_ENABLE_TESTING)
   ####Integration Tests####
   #########################
 
-  set(${PROJECT_NAME}_integrationtests
+  set(${PROJECT_NAME}_INTEGRATIONTEST_LIBRARIES
     sequence_capability
     pilz_command_planner
     planning_context_loader_ptp
@@ -235,7 +235,7 @@ if(CATKIN_ENABLE_TESTING)
   target_link_libraries(integrationtest_sequence_action_capability
     ${catkin_LIBRARIES}
     ${pilz_testutils_LIBRARIES}
-    ${${PROJECT_NAME}_integrationtests}
+    ${${PROJECT_NAME}_INTEGRATIONTEST_LIBRARIES}
   )
 
   add_rostest(test/integrationtest_sequence_action_capability_with_gripper.test
@@ -259,7 +259,7 @@ if(CATKIN_ENABLE_TESTING)
 
   target_link_libraries(integrationtest_sequence_service_capability
     ${catkin_LIBRARIES}
-    ${${PROJECT_NAME}_integrationtests}
+    ${${PROJECT_NAME}_INTEGRATIONTEST_LIBRARIES}
   )
 
   # Tests with other robots only for kinetic (for now)
@@ -283,7 +283,7 @@ if(CATKIN_ENABLE_TESTING)
 
   target_link_libraries(integrationtest_command_planning
     ${catkin_LIBRARIES}
-    ${${PROJECT_NAME}_integrationtests}
+    ${${PROJECT_NAME}_INTEGRATIONTEST_LIBRARIES}
   )
 
   add_rostest(test/integrationtest_command_planning_with_gripper.test
@@ -307,7 +307,7 @@ if(CATKIN_ENABLE_TESTING)
 
   target_link_libraries(integrationtest_command_list_manager
     ${catkin_LIBRARIES}
-    ${${PROJECT_NAME}_integrationtests}
+    ${${PROJECT_NAME}_INTEGRATIONTEST_LIBRARIES}
   )
 
   add_rostest_gtest(integrationtest_get_solver_tip_frame
@@ -317,7 +317,7 @@ if(CATKIN_ENABLE_TESTING)
 
   target_link_libraries(integrationtest_get_solver_tip_frame
     ${catkin_LIBRARIES}
-    ${${PROJECT_NAME}_integrationtests}
+    ${${PROJECT_NAME}_INTEGRATIONTEST_LIBRARIES}
   )
 
   add_rostest_gtest(integrationtest_plan_components_builder
@@ -327,7 +327,7 @@ if(CATKIN_ENABLE_TESTING)
 
   target_link_libraries(integrationtest_plan_components_builder
     ${catkin_LIBRARIES}
-    ${${PROJECT_NAME}_integrationtests}
+    ${${PROJECT_NAME}_INTEGRATIONTEST_LIBRARIES}
   )
 
 

--- a/pilz_trajectory_generation/CMakeLists.txt
+++ b/pilz_trajectory_generation/CMakeLists.txt
@@ -214,39 +214,17 @@ if(CATKIN_ENABLE_TESTING)
     APPEND_COVERAGE_COMPILER_FLAGS()
   endif()
 
-  ## Declare a C++ library
-  add_library(${PROJECT_NAME}_test
-      test/test_utils.cpp
-      src/trajectory_functions.cpp
-      src/joint_limits_aggregator.cpp
-      src/joint_limits_validator.cpp
-      src/trajectory_generator.cpp
-      src/trajectory_generator_ptp.cpp
-      src/trajectory_generator_lin.cpp
-      src/trajectory_generator_circ.cpp
-      src/path_circle_generator.cpp
-      src/velocity_profile_atrap.cpp
-      src/limits_container.cpp
-      src/joint_limits_container.cpp
-      src/cartesian_limit.cpp
-      src/command_list_manager.cpp
-      src/trajectory_blender_transition_window.cpp
-      src/cartesian_limits_aggregator.cpp
-      src/planning_context_loader.cpp
-      src/plan_components_builder.cpp
-      src/pilz_command_planner.cpp
-  )
-
-  target_link_libraries(${PROJECT_NAME}_test
-    ${catkin_LIBRARIES}
-  )
-
-add_dependencies(${PROJECT_NAME}_test
-            ${catkin_EXPORTED_TARGETS})
-
 #########################
 ####Integration Tests####
 #########################
+
+  set(${PROJECT_NAME}_integrationtests
+    sequence_capability
+    pilz_command_planner
+    planning_context_loader_ptp
+    planning_context_loader_lin
+    planning_context_loader_circ
+  )
 
 # Planning Integration tests
 add_rostest_gmock(integrationtest_sequence_action_capability
@@ -255,37 +233,28 @@ add_rostest_gmock(integrationtest_sequence_action_capability
 )
 
 target_link_libraries(integrationtest_sequence_action_capability
-   ${catkin_LIBRARIES} ${pilz_testutils_LIBRARIES} ${PROJECT_NAME}_test)
+   ${catkin_LIBRARIES} ${pilz_testutils_LIBRARIES} ${${PROJECT_NAME}_integrationtests})
 
-add_rostest_gmock(integrationtest_sequence_action_capability_with_gripper
-  test/integrationtest_sequence_action_capability_with_gripper.test
-  test/integrationtest_sequence_action_capability.cpp
+add_rostest(test/integrationtest_sequence_action_capability_with_gripper.test
+  DEPENDENCIES integrationtest_sequence_action_capability
 )
-target_link_libraries(integrationtest_sequence_action_capability_with_gripper
-   ${catkin_LIBRARIES} ${pilz_testutils_LIBRARIES} ${PROJECT_NAME}_test)
 
 # Tests with other robots only for kinetic (for now)
 
-#add_rostest_gmock(integrationtest_sequence_action_capability_abb_irb2400
-#  test/integrationtest_sequence_action_capability_abb_irb2400.test
-#  test/integrationtest_sequence_action_capability.cpp
+#add_rostest(test/integrationtest_sequence_action_capability_abb_irb2400.test
+#  DEPENDENCIES integrationtest_sequence_action_capability
 #)
-#target_link_libraries(integrationtest_sequence_action_capability_abb_irb2400
-#  ${catkin_LIBRARIES} ${pilz_testutils_LIBRARIES} ${PROJECT_NAME}_test)
 
-#add_rostest_gmock(integrationtest_sequence_action_capability_frankaemika_panda
-#  test/integrationtest_sequence_action_capability_frankaemika_panda.test
-#  test/integrationtest_sequence_action_capability.cpp
+#add_rostest(test/integrationtest_sequence_action_capability_frankaemika_panda.test
+#  DEPENDENCIES integrationtest_sequence_action_capability
 #)
-#target_link_libraries(integrationtest_sequence_action_capability_frankaemika_panda
-#  ${catkin_LIBRARIES} ${pilz_testutils_LIBRARIES} ${PROJECT_NAME}_test)
 
 add_rostest_gtest(integrationtest_sequence_service_capability
   test/integrationtest_sequence_service_capability.test
   test/integrationtest_sequence_service_capability.cpp
 )
 target_link_libraries(integrationtest_sequence_service_capability
-  ${catkin_LIBRARIES} ${PROJECT_NAME}_test)
+  ${catkin_LIBRARIES} ${${PROJECT_NAME}_integrationtests})
 
 # Tests with other robots only for kinetic (for now)
 
@@ -295,20 +264,18 @@ target_link_libraries(integrationtest_sequence_service_capability
 #add_rostest(test/integrationtest_sequence_service_capability_abb_irb2400.test
 #  DEPENDENCIES integrationtest_sequence_service_capability )
 
-add_rostest_gtest(integrationtest_sequence_service_capability_with_gripper
-  test/integrationtest_sequence_service_capability_with_gripper.test
-  test/integrationtest_sequence_service_capability.cpp
+add_rostest(test/integrationtest_sequence_service_capability_with_gripper.test
+  DEPENDENCIES integrationtest_sequence_service_capability
 )
-target_link_libraries(integrationtest_sequence_service_capability_with_gripper
-  ${catkin_LIBRARIES} ${PROJECT_NAME}_test)
 
 # Planning Integration tests
 add_rostest_gtest(integrationtest_command_planning
   test/integrationtest_command_planning.test
   test/integrationtest_command_planning.cpp
+  test/test_utils.cpp
 )
 target_link_libraries(integrationtest_command_planning
-   ${catkin_LIBRARIES} ${PROJECT_NAME}_test)
+   ${catkin_LIBRARIES} ${${PROJECT_NAME}_integrationtests})
 
 add_rostest(test/integrationtest_command_planning_with_gripper.test
   DEPENDENCIES integrationtest_command_planning )
@@ -325,23 +292,24 @@ add_rostest(test/integrationtest_command_planning_with_gripper.test
 add_rostest_gtest(integrationtest_command_list_manager
   test/integrationtest_command_list_manager.test
   test/integrationtest_command_list_manager.cpp
+  test/test_utils.cpp
 )
 target_link_libraries(integrationtest_command_list_manager
-${catkin_LIBRARIES} ${PROJECT_NAME}_test)
+${catkin_LIBRARIES} ${${PROJECT_NAME}_integrationtests})
 
 add_rostest_gtest(integrationtest_get_solver_tip_frame
   test/integrationtest_get_solver_tip_frame.test
   test/integrationtest_get_solver_tip_frame.cpp
 )
 target_link_libraries(integrationtest_get_solver_tip_frame
-${catkin_LIBRARIES} ${PROJECT_NAME}_test)
+${catkin_LIBRARIES} ${${PROJECT_NAME}_integrationtests})
 
 add_rostest_gtest(integrationtest_plan_components_builder
   test/integrationtest_plan_components_builder.test
   test/integrationtest_plan_components_builder.cpp
 )
 target_link_libraries(integrationtest_plan_components_builder
-${catkin_LIBRARIES} ${PROJECT_NAME}_test)
+${catkin_LIBRARIES} ${${PROJECT_NAME}_integrationtests})
 
 
 
@@ -349,23 +317,37 @@ ${catkin_LIBRARIES} ${PROJECT_NAME}_test)
 ####Unit Tests####
 ##################
 
+  add_library(${PROJECT_NAME}_testutils
+    test/test_utils.cpp
+    src/trajectory_generator.cpp
+    src/trajectory_generator_circ.cpp
+    src/trajectory_generator_lin.cpp
+    src/trajectory_generator_ptp.cpp
+    src/path_circle_generator.cpp
+    src/velocity_profile_atrap.cpp
+  )
+
+  target_link_libraries(${PROJECT_NAME}_testutils ${PROJECT_NAME})
+
   ## Add gtest based cpp test target and link libraries
   catkin_add_gtest(unittest_pilz_command_planner_direct
                    test/unittest_pilz_command_planner_direct.cpp
                    src/planning_context_loader_ptp.cpp)
   target_link_libraries(unittest_pilz_command_planner_direct
-    ${PROJECT_NAME} ${catkin_LIBRARIES} ${PROJECT_NAME}_test)
+    ${catkin_LIBRARIES} ${PROJECT_NAME}_testutils)
 
   ## Add gtest based cpp test target and link libraries
   catkin_add_gtest(unittest_velocity_profile_atrap
-                   test/unittest_velocity_profile_atrap.cpp)
+                   test/unittest_velocity_profile_atrap.cpp
+                   src/velocity_profile_atrap.cpp)
   target_link_libraries(unittest_velocity_profile_atrap
-    ${catkin_LIBRARIES} ${PROJECT_NAME}_test)
+    ${catkin_LIBRARIES})
 
   catkin_add_gtest(unittest_trajectory_generator
-                   test/unittest_trajectory_generator.cpp)
+                   test/unittest_trajectory_generator.cpp
+                   src/trajectory_generator.cpp)
   target_link_libraries(unittest_trajectory_generator
-    ${PROJECT_NAME} ${catkin_LIBRARIES} ${PROJECT_NAME}_test)
+    ${catkin_LIBRARIES} ${PROJECT_NAME})
 
   # Trajectory Generator Unit Test
   add_rostest_gtest(unittest_trajectory_functions
@@ -374,17 +356,18 @@ ${catkin_LIBRARIES} ${PROJECT_NAME}_test)
   )
 
   target_link_libraries(unittest_trajectory_functions
-    ${catkin_LIBRARIES}  ${PROJECT_NAME}_test)
+    ${catkin_LIBRARIES} ${PROJECT_NAME}_testutils)
 
 
   # unittest for trajectory blender transition window
   add_rostest_gtest(unittest_trajectory_blender_transition_window
     test/unittest_trajectory_blender_transition_window.test
     test/unittest_trajectory_blender_transition_window.cpp
+    src/trajectory_blender_transition_window.cpp
   )
 
   target_link_libraries(unittest_trajectory_blender_transition_window
-    ${catkin_LIBRARIES} ${PROJECT_NAME}_test)
+    ${catkin_LIBRARIES} ${PROJECT_NAME}_testutils)
 
   # trajectory generator Unit Test
   add_rostest_gtest(unittest_trajectory_generator_common
@@ -393,7 +376,7 @@ ${catkin_LIBRARIES} ${PROJECT_NAME}_test)
   )
 
   target_link_libraries(unittest_trajectory_generator_common
-      ${catkin_LIBRARIES} ${PROJECT_NAME}_test)
+      ${catkin_LIBRARIES} ${PROJECT_NAME}_testutils)
 
 
   # trajectory generator circ Unit Test
@@ -403,7 +386,7 @@ ${catkin_LIBRARIES} ${PROJECT_NAME}_test)
   )
 
   target_link_libraries(unittest_trajectory_generator_circ
-    ${catkin_LIBRARIES} ${PROJECT_NAME}_test)
+    ${catkin_LIBRARIES} ${PROJECT_NAME}_testutils)
 
   # trajectory generator lin Unit Test
   add_rostest_gtest(unittest_trajectory_generator_lin
@@ -412,7 +395,7 @@ ${catkin_LIBRARIES} ${PROJECT_NAME}_test)
   )
 
   target_link_libraries(unittest_trajectory_generator_lin
-      ${catkin_LIBRARIES} ${PROJECT_NAME}_test)
+      ${catkin_LIBRARIES} ${PROJECT_NAME}_testutils)
 
   # trajectory generator ptp Unit Test
   add_rostest_gtest(unittest_trajectory_generator_ptp
@@ -421,7 +404,7 @@ ${catkin_LIBRARIES} ${PROJECT_NAME}_test)
   )
 
   target_link_libraries(unittest_trajectory_generator_ptp
-    ${catkin_LIBRARIES} ${PROJECT_NAME}_test)
+    ${catkin_LIBRARIES} ${PROJECT_NAME}_testutils)
 
   # Command Planner Unit Test
   add_rostest_gtest(unittest_pilz_command_planner
@@ -430,7 +413,7 @@ ${catkin_LIBRARIES} ${PROJECT_NAME}_test)
   )
 
   target_link_libraries(unittest_pilz_command_planner
-    ${catkin_LIBRARIES} ${PROJECT_NAME}_test)
+    ${catkin_LIBRARIES} ${PROJECT_NAME})
 
   # JointLimitsAggregator Unit Test
   add_rostest_gtest(unittest_joint_limits_aggregator
@@ -439,7 +422,7 @@ ${catkin_LIBRARIES} ${PROJECT_NAME}_test)
   )
 
   target_link_libraries(unittest_joint_limits_aggregator
-      ${catkin_LIBRARIES} ${PROJECT_NAME}_test)
+      ${catkin_LIBRARIES} ${PROJECT_NAME})
 
   # JointLimitsContainer Unit Test
   catkin_add_gtest(unittest_joint_limits_container
@@ -447,7 +430,7 @@ ${catkin_LIBRARIES} ${PROJECT_NAME}_test)
   )
 
   target_link_libraries(unittest_joint_limits_container
-    ${catkin_LIBRARIES} ${PROJECT_NAME}_test)
+    ${catkin_LIBRARIES} ${PROJECT_NAME})
 
   # JointLimitsValidator Unit Test
   catkin_add_gtest(unittest_joint_limits_validator
@@ -455,7 +438,7 @@ ${catkin_LIBRARIES} ${PROJECT_NAME}_test)
   )
 
   target_link_libraries(unittest_joint_limits_validator
-     ${catkin_LIBRARIES} ${PROJECT_NAME}_test)
+     ${catkin_LIBRARIES} ${PROJECT_NAME})
 
    # Cartesian Limits Aggregator Unit Test
   add_rostest_gtest(unittest_cartesian_limits_aggregator
@@ -464,7 +447,7 @@ ${catkin_LIBRARIES} ${PROJECT_NAME}_test)
   )
 
   target_link_libraries(unittest_cartesian_limits_aggregator
-    ${catkin_LIBRARIES} ${PROJECT_NAME}_test)
+    ${catkin_LIBRARIES} ${PROJECT_NAME})
 
   # PlanningContextLoaderPTP Unit Test
   add_rostest_gtest(unittest_planning_context_loaders
@@ -473,16 +456,19 @@ ${catkin_LIBRARIES} ${PROJECT_NAME}_test)
   )
 
   target_link_libraries(unittest_planning_context_loaders
-    ${catkin_LIBRARIES} ${PROJECT_NAME}_test)
+    ${catkin_LIBRARIES} ${PROJECT_NAME}_testutils)
 
   # PlanningContext Unit Test (Typed test)
   add_rostest_gtest(unittest_planning_context
     test/unittest_planning_context.test
     test/unittest_planning_context.cpp
+    src/planning_context_loader_circ.cpp
+    src/planning_context_loader_lin.cpp
+    src/planning_context_loader_ptp.cpp
     )
 
   target_link_libraries(unittest_planning_context
-     ${catkin_LIBRARIES} ${PROJECT_NAME}_test)
+     ${catkin_LIBRARIES} ${PROJECT_NAME}_testutils)
 
   # GetTipFrames Unit Test
   catkin_add_gmock(unittest_get_solver_tip_frame
@@ -490,7 +476,7 @@ ${catkin_LIBRARIES} ${PROJECT_NAME}_test)
   )
 
   target_link_libraries(unittest_get_solver_tip_frame
-    ${catkin_LIBRARIES} ${PROJECT_NAME}_test)
+    ${catkin_LIBRARIES})
 
   # to run: catkin_make -DENABLE_COVERAGE_TESTING=ON package_name_coverage
   if(ENABLE_COVERAGE_TESTING)

--- a/pilz_trajectory_generation/test/integrationtest_sequence_action_capability_with_gripper.test
+++ b/pilz_trajectory_generation/test/integrationtest_sequence_action_capability_with_gripper.test
@@ -33,7 +33,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
   </include>
 
   <!-- run test -->
-  <test pkg="pilz_trajectory_generation" test-name="integrationtest_sequence_action_capability_with_gripper" type="integrationtest_sequence_action_capability_with_gripper" time-limit="300.0">
+  <test pkg="pilz_trajectory_generation" test-name="integrationtest_sequence_action_capability_with_gripper"
+        type="integrationtest_sequence_action_capability" time-limit="300.0">
     <param name="joint_position_tolerance" value="0.01" />
     <param name="testdata_file_name" value="$(find pilz_trajectory_generation)/test/test_robots/prbt/test_data/testdata_sequence.xml" />
   </test>

--- a/pilz_trajectory_generation/test/integrationtest_sequence_service_capability_with_gripper.test
+++ b/pilz_trajectory_generation/test/integrationtest_sequence_service_capability_with_gripper.test
@@ -35,7 +35,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
   </include>
 
   <!-- run test -->
-  <test pkg="pilz_trajectory_generation" test-name="integrationtest_sequence_service_capability" type="integrationtest_sequence_service_capability" time-limit="300.0">
+  <test pkg="pilz_trajectory_generation" test-name="integrationtest_sequence_service_capability_with_gripper"
+        type="integrationtest_sequence_service_capability" time-limit="300.0">
     <param name="testdata_file_name" value="$(find pilz_trajectory_generation)/test/test_robots/prbt/test_data/testdata_sequence.xml" />
   </test>
 


### PR DESCRIPTION
There exists a library `${PROJECT_NAME}_test`, which is linked to all tests. Essentially this is not enough for the integrationtests and too much for the unittests.

- [x] Link all libraries that are needed for integrationtests
- [x] Replace `${PROJECT_NAME}_test` with new library `${PROJECT_NAME}_testutils` for unittests
- [x] Make indentation of tests-block consistent

Side-effect: Reduces build-time by approx. 20s