### PR TITLE
Remove unused import of prbt_hardware_support

### DIFF
--- a/pilz_robot_programming/src/pilz_robot_programming/exceptions.py
+++ b/pilz_robot_programming/src/pilz_robot_programming/exceptions.py
@@ -15,8 +15,6 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from prbt_hardware_support.msg import BrakeTestErrorCodes
-
 
 class RobotVersionError(Exception):
     pass


### PR DESCRIPTION
This closes #240 since this unused import of prbt_hardware_support would not work since it is not declared in the package.xml. Which is correct since it is not needed in the first place.

Should get the documentation generated properly.