### PR TITLE
fix some python 3 compatibility issues

### DIFF
--- a/pilz_robot_programming/src/pilz_robot_programming/robot.py
+++ b/pilz_robot_programming/src/pilz_robot_programming/robot.py
@@ -30,7 +30,7 @@ from std_srvs.srv import Trigger
 import tf
 
 from pilz_msgs.msg import MoveGroupSequenceAction, IsBrakeTestRequiredResult
-from pilz_msgs.srv import GetSpeedOverride, IsBrakeTestRequired, BrakeTest, BrakeTestResponse
+from pilz_msgs.srv import GetSpeedOverride, IsBrakeTestRequired, BrakeTest
 
 from .move_control_request import _MoveControlState, MoveControlAction, _MoveControlStateMachine
 from .commands import _AbstractCmd, _DEFAULT_PLANNING_GROUP, _DEFAULT_TARGET_LINK, _DEFAULT_BASE_LINK, Sequence
@@ -322,7 +322,7 @@ class Robot(object):
             elif resp.result.value == IsBrakeTestRequiredResult.UNKNOWN:
                 rospy.logerr("Failure during call of braketest required service: BrakeTestRequirementStatus UNKNOWN")
                 raise rospy.ROSException("Could not determine if braketest is required.")
-        except rospy.ROSException, e:
+        except rospy.ROSException as e:
             rospy.logerr("Failure during call of braketest required service: {0}".format(e))
             raise e
 
@@ -340,10 +340,9 @@ class Robot(object):
 
         execute_brake_test_client = self._get_execute_brake_test_service()
 
-        resp = BrakeTestResponse()
         try:
             resp = execute_brake_test_client()
-        except rospy.ROSException, e:
+        except rospy.ROSException as e:
             rospy.logerr("Failure during call of braketest execute service: {0}".format(e))
             raise e
 
@@ -359,7 +358,7 @@ class Robot(object):
     def _get_execute_brake_test_service(self):
         try:
             rospy.wait_for_service(self._BRAKE_TEST_EXECUTE_SRV, self._SERVICE_WAIT_TIMEOUT_S)
-        except rospy.ROSException, e:
+        except rospy.ROSException as e:
             rospy.logerr(
                 "Unsuccessful waited for braketest execute service to come up: {0}".format(e))
             raise e
@@ -459,7 +458,8 @@ class Robot(object):
         else:
             return self._FAILURE
 
-    def _check_version(self, version):
+    @staticmethod
+    def _check_version(version):
         # check if version is set by user
         if version is None:
             rospy.logerr("Version of Robot API is not set!")
@@ -498,7 +498,7 @@ class Robot(object):
             if psutil.pid_exists(pid):
                 process = psutil.Process(pid)
 
-                if (process.create_time() == create_time):
+                if process.create_time() == create_time:
                     rospy.logerr("An instance of Robot class already exists (pid=" + str(pid) + ").")
                     return False
 


### PR DESCRIPTION
comma syntax for exception naming is no longer supported in python 3.
Drop unused type.