### PR TITLE
Attribute based equivalence for commands

### DIFF
--- a/pilz_robot_programming/CMakeLists.txt
+++ b/pilz_robot_programming/CMakeLists.txt
@@ -88,5 +88,4 @@ endfunction() # SETUP_TARGET_FOR_COVERAGE
           NAME ${PROJECT_NAME}_coverage
           )
   endif(ENABLE_COVERAGE_TESTING)
-
 endif()

--- a/pilz_robot_programming/src/pilz_robot_programming/commands.py
+++ b/pilz_robot_programming/src/pilz_robot_programming/commands.py
@@ -201,6 +201,28 @@ class BaseCmd(_AbstractCmd):
         out_str += " reference: " + str(self._reference_frame)
         return out_str
 
+    def __eq__(self, other):
+        if isinstance(other, BaseCmd):
+            return self._goal == other._goal \
+                   and self._planner_id == other._planner_id \
+                   and self._planning_group == other._planning_group \
+                   and self._target_link == other._target_link \
+                   and self._vel_scale == other._vel_scale \
+                   and self._acc_scale == other._acc_scale \
+                   and self._relative == other._relative \
+                   and self._reference_frame == other._reference_frame
+
+        return NotImplemented
+
+    def __ne__(self, other):
+        x = self.__eq__(other)
+        if x is not NotImplemented:
+            return not x
+        return NotImplemented
+
+    def __hash__(self):
+        return hash(tuple(sorted(self.__dict__.items())))
+
     __repr__ = __str__
 
     def _cmd_to_request(self, robot):
@@ -477,6 +499,14 @@ class Circ(BaseCmd):
         self._planner_id = "CIRC"
         self._interim = interim
         self._center = center
+
+    def __eq__(self, other):
+        if isinstance(other, Circ):
+            return super(Circ, self).__eq__(other) \
+                   and self._interim == other._interim \
+                   and self._center == other._center
+
+        return NotImplemented
 
     def __str__(self):
         out_str = BaseCmd.__str__(self)

--- a/pilz_robot_programming/src/pilz_robot_programming/commands.py
+++ b/pilz_robot_programming/src/pilz_robot_programming/commands.py
@@ -221,7 +221,7 @@ class BaseCmd(_AbstractCmd):
         return NotImplemented
 
     def __hash__(self):
-        return hash((hash(t) for t in tuple(map(lambda k: self.__dict__[k], sorted(self.__dict__.items())))))
+        return hash((hash(t) for t in tuple(sorted(self.__dict__.items()))))
 
     __repr__ = __str__
 

--- a/pilz_robot_programming/src/pilz_robot_programming/commands.py
+++ b/pilz_robot_programming/src/pilz_robot_programming/commands.py
@@ -221,7 +221,7 @@ class BaseCmd(_AbstractCmd):
         return NotImplemented
 
     def __hash__(self):
-        return hash(tuple(sorted(self.__dict__.items())))
+        return hash((hash(t) for t in tuple(map(lambda k: self.__dict__[k], sorted(self.__dict__.items())))))
 
     __repr__ = __str__
 

--- a/pilz_robot_programming/test/integrationtests/tst_api_cmd_conversion.py
+++ b/pilz_robot_programming/test/integrationtests/tst_api_cmd_conversion.py
@@ -1232,16 +1232,21 @@ class TestAPICmdConversion(unittest.TestCase):
         self.assertNotEqual(Ptp(), Circ())
         self.assertNotEqual(Ptp(), Lin())
         self.assertNotEqual(Circ(goal=[1], interim=Point(1, 3, 4)), Circ(goal=[1], center=Point(1, 3, 4)))
-        self.assertEqual(Ptp(planning_group="test"), Ptp(planning_group="test2"))
-        self.assertEqual(Ptp(target_link="prbt_tcp"), Ptp(target_link="world"))
-        self.assertEqual(Ptp(vel_scale=.1), Ptp(vel_scale=.2))
-        self.assertEqual(Ptp(acc_scale=.1), Ptp(acc_scale=.2))
-        self.assertEqual(Ptp(relative=False), Ptp(relative=True))
-        self.assertEqual(Ptp(reference_frame="prbt_tcp"), Ptp(reference_frame="world"))
-        self.assertEqual(Ptp(goal=Pose(position=Point(1, 2, 3), orientation=Quaternion(1, 0, 0, 0))),
-                         Ptp(goal=Pose(position=Point(3, 2, 1), orientation=Quaternion(1, 0, 0, 0))))
-        self.assertEqual(Ptp(goal=Pose(position=Point(1, 2, 3), orientation=Quaternion(1, 0, 0, 0))),
-                         Ptp(goal=Pose(position=Point(1, 2, 3), orientation=Quaternion(0, 0, 0, 1))))
+        self.assertNotEqual(Ptp(planning_group="test"), Ptp(planning_group="test2"))
+        self.assertNotEqual(Ptp(target_link="prbt_tcp"), Ptp(target_link="world"))
+        self.assertNotEqual(Ptp(vel_scale=.1), Ptp(vel_scale=.2))
+        self.assertNotEqual(Ptp(acc_scale=.1), Ptp(acc_scale=.2))
+        self.assertNotEqual(Ptp(relative=False), Ptp(relative=True))
+        self.assertNotEqual(Ptp(reference_frame="prbt_tcp"), Ptp(reference_frame="world"))
+        self.assertNotEqual(Ptp(goal=Pose(position=Point(1, 2, 3), orientation=Quaternion(1, 0, 0, 0))),
+                            Ptp(goal=Pose(position=Point(3, 2, 1), orientation=Quaternion(1, 0, 0, 0))))
+        self.assertNotEqual(Ptp(goal=Pose(position=Point(1, 2, 3), orientation=Quaternion(1, 0, 0, 0))),
+                            Ptp(goal=Pose(position=Point(1, 2, 3), orientation=Quaternion(0, 0, 0, 1))))
+
+        self.assertNotEqual(Ptp(), "")
+        self.assertNotEqual(Ptp(), "")
+        self.assertNotEqual(Circ(), "")
+        self.assertEqual(len({Ptp(), Ptp(), Circ()}), 2)
 
 
 if __name__ == '__main__':

--- a/pilz_robot_programming/test/integrationtests/tst_api_cmd_conversion.py
+++ b/pilz_robot_programming/test/integrationtests/tst_api_cmd_conversion.py
@@ -1208,6 +1208,41 @@ class TestAPICmdConversion(unittest.TestCase):
         str(Lin(goal=[0, 0, 0, 0, 0, 0], relative=True,
             reference_frame=ref, vel_scale=0.2, acc_scale=0.2))
 
+    def test_command_comparison(self):
+        """ Test if command comparison works as intended
+
+            Test sequence:
+                1. Create Commands
+                2. check the for equivalence and difference
+        """
+
+        self.assertEqual(Ptp(), Ptp())
+        self.assertEqual(Lin(), Lin())
+        self.assertEqual(Circ(), Circ())
+        self.assertEqual(Ptp(goal=[1, 3]), Ptp(goal=[1, 3]))
+        self.assertEqual(Ptp(planning_group="test"), Ptp(planning_group="test"))
+        self.assertEqual(Ptp(target_link="prbt_tcp"), Ptp(target_link="prbt_tcp"))
+        self.assertEqual(Ptp(vel_scale=.1), Ptp(vel_scale=.1))
+        self.assertEqual(Ptp(acc_scale=.1), Ptp(acc_scale=.1))
+        self.assertEqual(Ptp(relative=True), Ptp(relative=True))
+        self.assertEqual(Ptp(reference_frame="prbt_tcp"), Ptp(reference_frame="prbt_tcp"))
+        self.assertEqual(Ptp(goal=Pose(position=Point(1, 2, 3), orientation=Quaternion(1, 0, 0, 0))),
+                         Ptp(goal=Pose(position=Point(1, 2, 3), orientation=Quaternion(1, 0, 0, 0))))
+
+        self.assertNotEqual(Ptp(), Circ())
+        self.assertNotEqual(Ptp(), Lin())
+        self.assertNotEqual(Circ(goal=[1], interim=Point(1, 3, 4)), Circ(goal=[1], center=Point(1, 3, 4)))
+        self.assertEqual(Ptp(planning_group="test"), Ptp(planning_group="test2"))
+        self.assertEqual(Ptp(target_link="prbt_tcp"), Ptp(target_link="world"))
+        self.assertEqual(Ptp(vel_scale=.1), Ptp(vel_scale=.2))
+        self.assertEqual(Ptp(acc_scale=.1), Ptp(acc_scale=.2))
+        self.assertEqual(Ptp(relative=False), Ptp(relative=True))
+        self.assertEqual(Ptp(reference_frame="prbt_tcp"), Ptp(reference_frame="world"))
+        self.assertEqual(Ptp(goal=Pose(position=Point(1, 2, 3), orientation=Quaternion(1, 0, 0, 0))),
+                         Ptp(goal=Pose(position=Point(3, 2, 1), orientation=Quaternion(1, 0, 0, 0))))
+        self.assertEqual(Ptp(goal=Pose(position=Point(1, 2, 3), orientation=Quaternion(1, 0, 0, 0))),
+                         Ptp(goal=Pose(position=Point(1, 2, 3), orientation=Quaternion(0, 0, 0, 1))))
+
 
 if __name__ == '__main__':
     import rostest


### PR DESCRIPTION
I have implemented a command equivalence, that does not just compare the object, but its attributes. 
e.g currently: 
```
Ptp() == Ptp() 
False
```
with this PR its True:
```
Ptp() == Ptp()
True
Ptp() == Lin()
False
Ptp(goal=[1, 2]) == Ptp(goal=[1, 2])
True
```

Needed this to greatly reduce the effort for comparison in some tests.
Are there any arguments against including this as a feature into the api?