### PR TITLE
Deletes robot commander on shutdown to prevent it from segfaulting

### DIFF
--- a/pilz_robot_programming/src/pilz_robot_programming/robot.py
+++ b/pilz_robot_programming/src/pilz_robot_programming/robot.py
@@ -446,6 +446,8 @@ class Robot(object):
             first_iteration_flag = False
 
     def _on_shutdown(self):
+        if self.__robot_commander is not None:
+            del self.__robot_commander
         with self._move_ctrl_sm:  # wait, if _execute is just starting a send_goal()
             actionclient_state = self._sequence_client.get_state()
         # stop movement


### PR DESCRIPTION
Delete RobotController instance before shutting down ROS, to prevent a segfault originating from that class on a normal shutdown.
A Pull Request regarding this problem will be opened on moveit

Closes #263