### PR TITLE
WIP: Quadratic rule for determination of joint velocity

### DIFF
--- a/pilz_trajectory_generation/src/trajectory_functions.cpp
+++ b/pilz_trajectory_generation/src/trajectory_functions.cpp
@@ -287,10 +287,12 @@ bool pilz::generateJointTrajectory(const moveit::core::RobotModelConstPtr &robot
 
       if(time_iter!=time_samples.begin() && time_iter!=time_samples.end()-1)
       {
-        double joint_velocity = (ik_solution.at(joint_name) - ik_solution_last.at(joint_name))/duration_current_sample;
+        const double distance = ik_solution.at(joint_name) - ik_solution_last.at(joint_name);
+        // assuming a constant acceleration on the current time interval
+        const double joint_acceleration = 2*(distance - joint_velocity_last.at(joint_name)*duration_current_sample)/std::pow(duration_current_sample, 2);
+        const double joint_velocity = joint_velocity_last.at(joint_name) + joint_acceleration*duration_current_sample;
         point.velocities.push_back(joint_velocity);
-        point.accelerations.push_back((joint_velocity - joint_velocity_last.at(joint_name))/(duration_current_sample
-                                                                                             +sampling_time)*2);
+        point.accelerations.push_back(joint_acceleration);
         joint_velocity_last[joint_name] = joint_velocity;
       }
       else


### PR DESCRIPTION
Target: #311

Looks promising, but needs more investigation. The pictures below show that the oscillations at the acceleration-part of the LIN trajectory are dissolved.

Before:
![lin_acceleration_limit_violation](https://user-images.githubusercontent.com/35950815/88272751-80da9680-ccd9-11ea-8bed-ba0157fefa0d.png)

After:
![lin_acceleration_limit_violation_quadratic_rule](https://user-images.githubusercontent.com/35950815/88272762-86d07780-ccd9-11ea-8492-95aa8a8b3433.png)


