### PR TITLE
Add command planning tests for universal robot ur3

### DIFF
--- a/pilz_trajectory_generation/CMakeLists.txt
+++ b/pilz_trajectory_generation/CMakeLists.txt
@@ -302,6 +302,16 @@ if(CATKIN_ENABLE_TESTING)
   #add_rostest(test/integrationtest_command_planning_frankaemika_panda.test
   #  DEPENDENCIES integrationtest_command_planning )
 
+  add_rostest_gtest(integrationtest_ur3
+    test/integrationtest_ur3.test
+    test/integrationtest_ur3.cpp
+    test/test_utils.cpp
+  )
+  target_link_libraries(integrationtest_ur3
+    ${catkin_LIBRARIES}
+    ${${PROJECT_NAME}_INTEGRATIONTEST_LIBRARIES}
+  )
+
   # Blending Integration tests
   add_rostest_gtest(integrationtest_command_list_manager
     test/integrationtest_command_list_manager.test

--- a/pilz_trajectory_generation/test/integrationtest_ur3.cpp
+++ b/pilz_trajectory_generation/test/integrationtest_ur3.cpp
@@ -1,0 +1,294 @@
+/*
+ * Copyright (c) 2020 Pilz GmbH & Co. KG
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <gtest/gtest.h>
+
+#include <iostream>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include <ros/ros.h>
+
+#include <eigen_conversions/eigen_msg.h>
+
+#include <moveit/kinematic_constraints/utils.h>
+#include <moveit/planning_interface/planning_request.h>
+#include <moveit/robot_model_loader/robot_model_loader.h>
+#include <moveit/robot_state/conversions.h>
+#include <moveit_msgs/Constraints.h>
+#include <moveit_msgs/GetMotionPlan.h>
+#include <moveit_msgs/JointConstraint.h>
+
+#include <pilz_industrial_motion_testutils/command_types_typedef.h>
+#include <pilz_industrial_motion_testutils/xml_testdata_loader.h>
+
+#include "test_utils.h"
+
+const double EPSILON = 1.0e-6;
+const std::string PLAN_SERVICE_NAME = "/plan_kinematic_path";
+
+// Parameters from parameter server
+const std::string PARAM_PLANNING_GROUP_NAME("planning_group");
+const std::string POSE_TRANSFORM_MATRIX_NORM_TOLERANCE("pose_norm_tolerance");
+const std::string ORIENTATION_NORM_TOLERANCE("orientation_norm_tolerance");
+const std::string PARAM_TARGET_LINK_NAME("target_link");
+const std::string TEST_DATA_FILE_NAME("testdata_file_name");
+
+using namespace pilz_industrial_motion_testutils;
+
+/**
+ * PLEASE NOTE:
+ * More detailed lin tests are done via unit tests. With the help of the
+ * integration tests, it is only checked that a linear command actually
+ * performs a linear command.
+ */
+class IntegrationTestCommandPlanning : public ::testing::Test {
+protected:
+  void SetUp() override;
+
+protected:
+  ros::NodeHandle ph_{"~"};
+
+  robot_model::RobotModelPtr robot_model_;
+
+  double pose_norm_tolerance_, orientation_norm_tolerance_;
+  std::string planning_group_, target_link_, test_data_file_name_;
+
+  std::unique_ptr<pilz_industrial_motion_testutils::TestdataLoader> test_data_;
+
+  unsigned int num_joints_{0};
+};
+
+void IntegrationTestCommandPlanning::SetUp() {
+  // create robot model
+  robot_model_loader::RobotModelLoader model_loader;
+  robot_model_ = model_loader.getModel();
+
+  // get the parameters
+  ASSERT_TRUE(ph_.getParam(PARAM_PLANNING_GROUP_NAME, planning_group_));
+  ASSERT_TRUE(
+      ph_.getParam(POSE_TRANSFORM_MATRIX_NORM_TOLERANCE, pose_norm_tolerance_));
+  ASSERT_TRUE(ph_.getParam(PARAM_TARGET_LINK_NAME, target_link_));
+  ASSERT_TRUE(
+      ph_.getParam(ORIENTATION_NORM_TOLERANCE, orientation_norm_tolerance_));
+  ASSERT_TRUE(ph_.getParam(TEST_DATA_FILE_NAME, test_data_file_name_));
+
+  // load the test data provider
+  test_data_.reset(new pilz_industrial_motion_testutils::XmlTestdataLoader{
+      test_data_file_name_, robot_model_});
+  ASSERT_NE(nullptr, test_data_) << "Failed to load test data by provider.";
+
+  num_joints_ = robot_model_->getJointModelGroup(planning_group_)
+                    ->getActiveJointModelNames()
+                    .size();
+}
+
+/**
+ * @brief Tests if ptp motions with start & goal state given as
+ * joint configuration are executed correctly.
+ *
+ * Test Sequence:
+ *    1. Generate request with joint goal and start state call planning service.
+ *
+ * Expected Results:
+ *    1. Last point of the resulting trajectory is at the goal
+ */
+TEST_F(IntegrationTestCommandPlanning, PtpJoint) {
+  ros::NodeHandle node_handle("~");
+  auto ptp{test_data_->getPtpJoint("Ptp1")};
+
+  moveit_msgs::GetMotionPlan srv;
+  moveit_msgs::MotionPlanRequest req = ptp.toRequest();
+  srv.request.motion_plan_request = req;
+
+  ASSERT_TRUE(ros::service::waitForService(
+      PLAN_SERVICE_NAME, ros::Duration(testutils::DEFAULT_SERVICE_TIMEOUT)));
+  ros::ServiceClient client =
+      node_handle.serviceClient<moveit_msgs::GetMotionPlan>(PLAN_SERVICE_NAME);
+
+  ASSERT_TRUE(client.call(srv));
+  const moveit_msgs::MotionPlanResponse &response{
+      srv.response.motion_plan_response};
+
+  // Check the result
+  ASSERT_EQ(moveit_msgs::MoveItErrorCodes::SUCCESS, response.error_code.val)
+      << "Planning failed!";
+  trajectory_msgs::JointTrajectory trajectory =
+      response.trajectory.joint_trajectory;
+
+  EXPECT_EQ(trajectory.joint_names.size(), num_joints_)
+      << "Wrong number of jointnames";
+  EXPECT_GT(trajectory.points.size(), 0u)
+      << "There are no points in the trajectory";
+
+  // Check that every point has position, velocity, acceleration
+  for (trajectory_msgs::JointTrajectoryPoint point : trajectory.points) {
+    EXPECT_EQ(point.positions.size(), num_joints_);
+    EXPECT_EQ(point.velocities.size(), num_joints_);
+    EXPECT_EQ(point.accelerations.size(), num_joints_);
+  }
+
+  for (size_t i = 0; i < num_joints_; ++i) {
+    EXPECT_NEAR(trajectory.points.back().positions.at(i),
+                req.goal_constraints.back().joint_constraints.at(i).position,
+                10e-10);
+    EXPECT_NEAR(trajectory.points.back().velocities.at(i), 0, 10e-10);
+    // EXPECT_NEAR(trajectory.points.back().accelerations.at(i), 0, 10e-10); //
+    // TODO what is expected
+  }
+}
+
+/**
+ * @brief Tests if ptp motions with start state given as joint configuration
+ * and goal state given as cartesian configuration are executed correctly.
+ *
+ * Test Sequence:
+ *    1. Generate request with pose goal and start state call planning service.
+ *
+ * Expected Results:
+ *    1. Last point of the resulting trajectory is at the goal
+ */
+TEST_F(IntegrationTestCommandPlanning, PtpJointCart) {
+  ros::NodeHandle node_handle("~");
+
+  PtpJointCart ptp{test_data_->getPtpJointCart("Ptp1")};
+  ptp.getGoalConfiguration().setPoseTolerance(0.01);
+  ptp.getGoalConfiguration().setAngleTolerance(0.01);
+
+  moveit_msgs::GetMotionPlan srv;
+  srv.request.motion_plan_request = ptp.toRequest();
+
+  ASSERT_TRUE(ros::service::waitForService(
+      PLAN_SERVICE_NAME, ros::Duration(testutils::DEFAULT_SERVICE_TIMEOUT)));
+  ros::ServiceClient client =
+      node_handle.serviceClient<moveit_msgs::GetMotionPlan>(PLAN_SERVICE_NAME);
+
+  ASSERT_TRUE(client.call(srv));
+  const moveit_msgs::MotionPlanResponse &response{
+      srv.response.motion_plan_response};
+
+  // Make sure the planning succeeded
+  ASSERT_EQ(moveit_msgs::MoveItErrorCodes::SUCCESS, response.error_code.val)
+      << "Planning failed!";
+
+  // Check the result
+  trajectory_msgs::JointTrajectory trajectory =
+      response.trajectory.joint_trajectory;
+
+  EXPECT_EQ(trajectory.joint_names.size(), num_joints_)
+      << "Wrong number of jointnames";
+  EXPECT_GT(trajectory.points.size(), 0u)
+      << "There are no points in the trajectory";
+
+  // Check that every point has position, velocity, acceleration
+  for (trajectory_msgs::JointTrajectoryPoint point : trajectory.points) {
+    EXPECT_EQ(point.positions.size(), num_joints_);
+    EXPECT_EQ(point.velocities.size(), num_joints_);
+    EXPECT_EQ(point.accelerations.size(), num_joints_);
+  }
+
+  // TODO check that at right position
+  robot_state::RobotState rstate(robot_model_);
+  rstate.setJointGroupPositions(
+      planning_group_,
+      response.trajectory.joint_trajectory.points.back().positions);
+  rstate.update();
+  Eigen::Isometry3d tf = rstate.getFrameTransform(target_link_);
+
+  const geometry_msgs::Pose &expected_pose{
+      ptp.getGoalConfiguration().getPose()};
+  EXPECT_NEAR(tf(0, 3), expected_pose.position.x, EPSILON);
+  EXPECT_NEAR(tf(1, 3), expected_pose.position.y, EPSILON);
+  EXPECT_NEAR(tf(2, 3), expected_pose.position.z, EPSILON);
+
+  Eigen::Isometry3d exp_iso3d_pose;
+  tf::poseMsgToEigen(expected_pose, exp_iso3d_pose);
+
+  EXPECT_TRUE(
+      Eigen::Quaterniond(tf.rotation())
+          .isApprox(Eigen::Quaterniond(exp_iso3d_pose.rotation()), EPSILON));
+}
+
+TEST_F(IntegrationTestCommandPlanning, PtpCart) {
+  ros::NodeHandle node_handle("~");
+
+  PtpCart ptp{test_data_->getPtpCart("Ptp2")};
+  ptp.getGoalConfiguration().setPoseTolerance(0.01);
+  ptp.getGoalConfiguration().setAngleTolerance(0.01);
+
+  moveit_msgs::GetMotionPlan srv;
+  srv.request.motion_plan_request = ptp.toRequest();
+
+  ASSERT_TRUE(ros::service::waitForService(
+      PLAN_SERVICE_NAME, ros::Duration(testutils::DEFAULT_SERVICE_TIMEOUT)));
+  ros::ServiceClient client =
+      node_handle.serviceClient<moveit_msgs::GetMotionPlan>(PLAN_SERVICE_NAME);
+
+  ASSERT_TRUE(client.call(srv));
+  const moveit_msgs::MotionPlanResponse &response{
+      srv.response.motion_plan_response};
+
+  // Make sure the planning succeeded
+  ASSERT_EQ(moveit_msgs::MoveItErrorCodes::SUCCESS, response.error_code.val)
+      << "Planning failed!";
+
+  // Check the result
+  trajectory_msgs::JointTrajectory trajectory =
+      response.trajectory.joint_trajectory;
+
+  EXPECT_EQ(trajectory.joint_names.size(), num_joints_)
+      << "Wrong number of jointnames";
+  EXPECT_GT(trajectory.points.size(), 0u)
+      << "There are no points in the trajectory";
+
+  // Check that every point has position, velocity, acceleration
+  for (trajectory_msgs::JointTrajectoryPoint point : trajectory.points) {
+    EXPECT_EQ(point.positions.size(), num_joints_);
+    EXPECT_EQ(point.velocities.size(), num_joints_);
+    EXPECT_EQ(point.accelerations.size(), num_joints_);
+  }
+
+  // TODO check that at right position
+  robot_state::RobotState rstate(robot_model_);
+  rstate.setJointGroupPositions(
+      planning_group_,
+      response.trajectory.joint_trajectory.points.back().positions);
+  rstate.update();
+  Eigen::Isometry3d tf = rstate.getFrameTransform(target_link_);
+
+  const geometry_msgs::Pose &expected_pose{
+      ptp.getGoalConfiguration().getPose()};
+  EXPECT_NEAR(tf(0, 3), expected_pose.position.x, EPSILON);
+  EXPECT_NEAR(tf(1, 3), expected_pose.position.y, EPSILON);
+  EXPECT_NEAR(tf(2, 3), expected_pose.position.z, EPSILON);
+
+  Eigen::Isometry3d exp_iso3d_pose;
+  tf::poseMsgToEigen(expected_pose, exp_iso3d_pose);
+
+  EXPECT_TRUE(
+      Eigen::Quaterniond(tf.rotation())
+          .isApprox(Eigen::Quaterniond(exp_iso3d_pose.rotation()), EPSILON));
+}
+
+int main(int argc, char **argv) {
+  ros::init(argc, argv, "integrationtest_ur3");
+  ros::NodeHandle nh; // For output via ROS_ERROR etc during test
+
+  testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/pilz_trajectory_generation/test/integrationtest_ur3.test
+++ b/pilz_trajectory_generation/test/integrationtest_ur3.test
@@ -1,0 +1,44 @@
+<!--
+Copyright (c) 2018 Pilz GmbH & Co. KG
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+-->
+
+<launch>
+
+<node name="joint_state_publisher" pkg="joint_state_publisher" type="joint_state_publisher">
+  <param name="/use_gui" value="false"/>
+  <rosparam param="/source_list">[/move_group/fake_controller_joint_states]</rosparam>
+</node>
+
+<node name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher" respawn="true" output="screen" />
+
+<arg name="debug" default="false"/>
+<include file="$(find pilz_trajectory_generation)/test/test_robots/universal_robot_ur3/launch/move_group.launch">
+  <arg name="allow_trajectory_execution" value="true"/>
+  <arg name="fake_execution" value="true"/>
+  <arg name="info" value="true"/>
+  <arg name="debug" value="$(arg debug)"/>
+</include>
+
+<!-- run test -->
+<test pkg="pilz_trajectory_generation" test-name="integrationtest_ur3" type="integrationtest_ur3">
+  <param name="testdata_file_name" value="$(find pilz_trajectory_generation)/test/test_robots/universal_robot_ur3/test_data/testdata.xml" />
+  <param name="planning_group" value="manipulator" />
+  <param name="target_link" value="tool0" />
+  <param name="pose_norm_tolerance" value="1.0e-5" />
+  <param name="orientation_norm_tolerance" value="1.0e-5" />
+</test>
+
+</launch>

--- a/pilz_trajectory_generation/test/test_robots/universal_robot_ur3/README.md
+++ b/pilz_trajectory_generation/test/test_robots/universal_robot_ur3/README.md
@@ -1,0 +1,7 @@
+# Integration test setup for ur3
+- Use [ros-industrial/universal_robot](https://github.com/ros-industrial/universal_robot) repository for `melodic-devel` support of universal robot ur3.
+- To use the launch files of the ur3 provided by [ros-industrial/universal_robot](https://github.com/ros-industrial/universal_robot) repository, the end-effector group `endeffector` must be commented out in `ur3_moveit_config/config/ur3.srdf`.  
+  
+**Please note:**  
+It necessary to comment out the `endeffector` group because the `pilz_command_planner` states that the limits for the joints in the `endeffector` group are not set. (The `endeffector` group in the default `ur3.srdf` file actually consists of no joints, still the `pilz_command_planner` gives the before mentioned error message.)
+

--- a/pilz_trajectory_generation/test/test_robots/universal_robot_ur3/launch/move_group.launch
+++ b/pilz_trajectory_generation/test/test_robots/universal_robot_ur3/launch/move_group.launch
@@ -1,0 +1,66 @@
+<launch>
+  <!-- Enables the usage of the ur3 in tests by starting and configuring all required ROS components -->
+
+  <arg name="limited" default="false"/>
+
+  <include file="$(find ur3_moveit_config)/launch/planning_context.launch">
+    <arg name="load_robot_description" value="true" />
+    <arg name="limited" value="$(arg limited)"/>
+  </include>
+
+  <!-- Load cartesian limits -->
+  <group ns="robot_description_planning">
+    <rosparam command="load" file="$(find pilz_trajectory_generation)/test/test_robots/config/cartesian_limits.yaml"/>
+  </group>
+
+  <arg name="pipeline" default="pilz_command_planner" />
+
+  <!-- GDB Debug Option -->
+  <arg name="debug" default="false" />
+  <arg unless="$(arg debug)" name="launch_prefix" value="" />
+  <arg     if="$(arg debug)" name="launch_prefix" value="gdb --ex run --args" />
+
+  <!-- Verbose Mode Option -->
+  <arg name="info" default="$(arg debug)" />
+  <arg unless="$(arg info)" name="command_args" value="" />
+  <arg     if="$(arg info)" name="command_args" value="--debug" />
+
+  <!-- move_group settings -->
+  <arg name="allow_trajectory_execution" default="true"/>
+  <arg name="fake_execution" default="false"/>
+  <arg name="max_safe_path_cost" default="1"/>
+  <arg name="jiggle_fraction" default="0.05" />
+  <arg name="publish_monitored_planning_scene" default="true"/>
+
+  <!-- Planning Functionality -->
+  <param name="move_group/planning_plugin" value="pilz::CommandPlanner" />
+
+  <!-- Trajectory Execution Functionality -->
+  <include ns="move_group" file="$(find ur3_moveit_config)/launch/trajectory_execution.launch.xml" if="$(arg allow_trajectory_execution)">
+    <arg name="moveit_manage_controllers" value="true" />
+    <arg name="moveit_controller_manager" value="ur3" unless="$(arg fake_execution)"/>
+    <arg name="moveit_controller_manager" value="fake" if="$(arg fake_execution)"/>
+  </include>
+
+  <!-- Start the actual move_group node/action server -->
+  <node name="move_group" launch-prefix="$(arg launch_prefix)" pkg="moveit_ros_move_group" type="move_group" respawn="false" output="screen" args="$(arg command_args)">
+    <!-- Set the display variable, in case OpenGL code is used internally -->
+    <env name="DISPLAY" value="$(optenv DISPLAY :0)" />
+
+    <param name="allow_trajectory_execution" value="$(arg allow_trajectory_execution)"/>
+    <param name="max_safe_path_cost" value="$(arg max_safe_path_cost)"/>
+    <param name="jiggle_fraction" value="$(arg jiggle_fraction)" />
+
+    <!-- MoveGroup capabilities to load -->
+    <param name="capabilities" value="pilz_trajectory_generation/MoveGroupSequenceAction
+                                      pilz_trajectory_generation/MoveGroupSequenceService
+                      " />
+
+    <!-- Publish the planning scene of the physical robot so that rviz plugin can know actual robot -->
+    <param name="planning_scene_monitor/publish_planning_scene" value="$(arg publish_monitored_planning_scene)" />
+    <param name="planning_scene_monitor/publish_geometry_updates" value="$(arg publish_monitored_planning_scene)" />
+    <param name="planning_scene_monitor/publish_state_updates" value="$(arg publish_monitored_planning_scene)" />
+    <param name="planning_scene_monitor/publish_transforms_updates" value="$(arg publish_monitored_planning_scene)" />
+  </node>
+
+</launch>

--- a/pilz_trajectory_generation/test/test_robots/universal_robot_ur3/launch/run_ur3.launch
+++ b/pilz_trajectory_generation/test/test_robots/universal_robot_ur3/launch/run_ur3.launch
@@ -1,0 +1,40 @@
+<!--
+Copyright (c) 2020 Pilz GmbH & Co. KG
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+-->
+
+<launch>
+
+  <node name="joint_state_publisher" pkg="joint_state_publisher" type="joint_state_publisher">
+    <param name="/use_gui" value="false"/>
+    <rosparam param="/source_list">[/move_group/fake_controller_joint_states]</rosparam>
+  </node>
+
+  <node name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher" respawn="true" output="screen" />
+
+  <arg name="debug" default="false"/>
+  <include file="$(find pilz_trajectory_generation)/test/test_robots/universal_robot_ur3/launch/move_group.launch">
+    <arg name="allow_trajectory_execution" value="true"/>
+    <arg name="fake_execution" value="true"/>
+    <arg name="info" value="true"/>
+    <arg name="debug" value="$(arg debug)"/>
+  </include>
+
+  <include file="$(find ur3_moveit_config)/launch/moveit_rviz.launch">
+    <arg name="config" value="true"/>
+    <arg name="debug" value="$(arg debug)"/>
+  </include>
+
+</launch>

--- a/pilz_trajectory_generation/test/test_robots/universal_robot_ur3/test_data/testdata.xml
+++ b/pilz_trajectory_generation/test/test_robots/universal_robot_ur3/test_data/testdata.xml
@@ -1,0 +1,63 @@
+<!--
+Copyright (c) 2020 Pilz GmbH & Co. KG
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+-->
+
+<testdata>
+
+  <!-- See ../../concept_testdata.png for a visualization of the concept behind these points -->
+
+  <poses>
+
+    <pos name="ZeroPose">
+      <joints group_name="manipulator">0.0 0.0 0.0 0.0 0.0 0.0</joints>
+    </pos>
+
+    <pos name="P1">
+      <joints group_name="manipulator">-0.170863 -0.909598 0.9075894 0.002010 -0.170863 0.</joints>
+      <xyzQuat group_name="manipulator" link_name="tool0">0.376685 0.130915 0.259281 0. 0.70711 0.70711 0.</xyzQuat>
+    </pos>
+
+    <pos name="P2">
+      <joints group_name="manipulator">6.169920 5.585564 1.229269 -0.531648 -0.113264 -6.283184</joints>
+      <xyzQuat group_name="manipulator" link_name="tool0">0.38087 0.15165 0.11496 0. 0.70711 0.70711 0.</xyzQuat>
+    </pos>
+
+  </poses>
+
+
+  <ptps>
+
+    <ptp name="Ptp1">
+      <planningGroup>manipulator</planningGroup>
+      <targetLink>tool0</targetLink>
+      <startPos>ZeroPose</startPos>
+      <endPos>P1</endPos>
+      <vel>1.0</vel>
+      <acc>0.3</acc>
+    </ptp>
+
+    <ptp name="Ptp2">
+      <planningGroup>manipulator</planningGroup>
+      <targetLink>tool0</targetLink>
+      <startPos>P1</startPos>
+      <endPos>P2</endPos>
+      <vel>1.0</vel>
+      <acc>0.3</acc>
+    </ptp>
+
+  </ptps>
+
+</testdata>


### PR DESCRIPTION
PR to investigate if it possible to use the universal robot ur3 in combination with the `pilz_command_planner`. This PR is based on issue #314.