### PR TITLE
Fix catkin_lint problem in pilz_industrial_motion

### DIFF
--- a/pilz_trajectory_generation/CMakeLists.txt
+++ b/pilz_trajectory_generation/CMakeLists.txt
@@ -56,6 +56,7 @@ endif()
 ###################################
 catkin_package(
   CATKIN_DEPENDS
+  roscpp
   moveit_msgs
   pilz_msgs
   tf2_geometry_msgs


### PR DESCRIPTION
Fix for:
![catkin_lint_error](https://user-images.githubusercontent.com/40654276/99544718-eb17f500-29b4-11eb-9a41-8147d7cf6107.png)
