### PR TITLE
Add missing test depend on prbt_hardware_support

### DIFF
--- a/pilz_robot_programming/package.xml
+++ b/pilz_robot_programming/package.xml
@@ -32,6 +32,7 @@
   <test_depend>pilz_industrial_motion_testutils</test_depend>
   <test_depend>python-coverage</test_depend>
   <test_depend>python-mock</test_depend>
+  <test_depend>prbt_hardware_support</test_depend>
   <test_depend>prbt_moveit_config</test_depend>
   <test_depend>prbt_pg70_support</test_depend>
   <test_depend>rostest</test_depend>


### PR DESCRIPTION
e.g. needed here:
https://github.com/PilzDE/pilz_industrial_motion/blob/bd4b3a7c2464b4382765fdd49e5f6c28f9e96623/pilz_robot_programming/test/integrationtests/integrationtest_self_collision.test#L41