### PR TITLE
Dont check joint model groups containing only fixed joints

### DIFF
--- a/pilz_trajectory_generation/src/trajectory_generator_ptp.cpp
+++ b/pilz_trajectory_generation/src/trajectory_generator_ptp.cpp
@@ -40,7 +40,15 @@ TrajectoryGeneratorPTP::TrajectoryGeneratorPTP(const robot_model::RobotModelCons
   // collect most strict joint limits for each group in robot model
   for(const auto& jmg : robot_model->getJointModelGroups())
   {
-    pilz_extensions::JointLimit most_strict_limit = joint_limits_.getCommonLimit(jmg->getActiveJointModelNames());
+    auto active_joints = jmg->getActiveJointModelNames();
+
+    // no active joints
+    if(active_joints.empty())
+    {
+      continue;
+    }
+
+    pilz_extensions::JointLimit most_strict_limit = joint_limits_.getCommonLimit(active_joints);
 
     if(!most_strict_limit.has_velocity_limits)
     {


### PR DESCRIPTION
## Description

Some group joint model groups may not have any active joints, this seams counter intuitive but its common to have a group for an end effector which may consist of only fixed joints.

This small changes skips over the group if it has no active joint names and prevents the error when planning a PTP such as:

```
[ERROR] [1609780343.558658315]: velocity limit not set for group end_effector
[ERROR] [1609780343.559382469]: Exception caught: 'velocity limit not set for group end_effector'
```

### Things to add, update or check by the maintainers before this PR can be merged.

* [ ] Public api function documentation
* [ ] Architecture documentation reflects actual code structure
* [ ] [Tutorials](https://wiki.ros.org/pilz_robots/Tutorials/)
* [ ] Overview on [ROS wiki](https://wiki.ros.org/pilz_robots)
* [ ] Package Readme ([example pilz_robots](https://github.com/PilzDE/pilz_robots/blob/melodic-devel/README.md))
* [ ] Good commit messages ([some tips](https://dev.to/jacobherrington/how-to-write-useful-commit-messages-my-commit-message-template-20n9))
* [ ] CHANGELOG.rst updated
* [ ] Copyright headers
* [ ] Examples

### Review Checklist
* [ ] Soft- and hardware architecture (diagrams and description)
* [ ] Test review (test plan and individual test cases)
* [ ] Documentation describes purpose of file(s) and responsibilities
* [ ] Code (coding rules, style guide)

### Release planning (please answer)
* [ ] When is the new feature released?
* [ ] Which dependent packages do have to be released simultaneously?
