### PR TITLE
[melodic] Fix key error on calling release twice

### DIFF
--- a/pilz_robot_programming/CHANGELOG.rst
+++ b/pilz_robot_programming/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package pilz_robot_programming
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+Forthcoming
+-----------
+* Fix key error on calling Robot._release() twice
+* Contributors: Pilz GmbH and Co. KG
+
 0.4.12 (2020-11-24)
 -------------------
 * Adapt to generalized test-utils

--- a/pilz_robot_programming/src/pilz_robot_programming/robot.py
+++ b/pilz_robot_programming/src/pilz_robot_programming/robot.py
@@ -554,7 +554,11 @@ class Robot(object):
         # do not delete pid parameter if it has not been set or overwritten
         if self._single_instance_flag:
             rospy.logdebug("Delete single instance parameter from parameter server.")
-            rospy.delete_param(self._INSTANCE_PARAM)
+            try:
+                rospy.delete_param(self._INSTANCE_PARAM)
+            except KeyError:
+                rospy.logdebug("Instance parameter was missing.")
+            self._single_instace_flag = False
 
     def __enter__(self):
         return self

--- a/pilz_robot_programming/test/integrationtests/tst_api_instantiation.py
+++ b/pilz_robot_programming/test/integrationtests/tst_api_instantiation.py
@@ -119,6 +119,15 @@ class TestAPIInstantiation(unittest.TestCase):
                 r2._release()
                 self.fail('Multiple robot instances does not throw exception.')
 
+    def test_double_release(self):
+        """ Checks that calling _release() a second time doesn't throw an exception."""
+        r = Robot(API_VERSION)
+        r._release()
+        try:
+            r._release()
+        except KeyError as e:
+            self.fail('Second _release() throws: ' + e.message)
+
 
 if __name__ == '__main__':
     import rostest


### PR DESCRIPTION
## Description

These changes fix the termination of a program on calling `Robot._release()` twice. (backport from noetic-devel)

### Things to add, update or check by the maintainers before this PR can be merged.

* [x] Public api function documentation
* [x] Architecture documentation reflects actual code structure
* [x] [Tutorials](https://wiki.ros.org/pilz_robots/Tutorials/)
* [x] Overview on [ROS wiki](https://wiki.ros.org/pilz_robots)
* [x] Package Readme ([example pilz_robots](https://github.com/PilzDE/pilz_robots/blob/melodic-devel/README.md))
* [x] Good commit messages ([some tips](https://dev.to/jacobherrington/how-to-write-useful-commit-messages-my-commit-message-template-20n9))
* [x] CHANGELOG.rst updated
* [x] Copyright headers
* [x] Examples

### Review Checklist
* [ ] Soft- and hardware architecture (diagrams and description)
* [ ] Test review (test plan and individual test cases)
* [ ] Documentation describes purpose of file(s) and responsibilities
* [ ] Code (coding rules, style guide)

### Release planning (please answer)
* [x] When is the new feature released? Does not seem urgent.
* [x] Which dependent packages do have to be released simultaneously? None
