### PR TITLE
Adjust blend radius in test data

### DIFF
--- a/pilz_robot_programming/test/test_data/test_data.xml
+++ b/pilz_robot_programming/test/test_data/test_data.xml
@@ -267,13 +267,13 @@ limitations under the License.
 
     <sequences>
         <sequence name="LINLINBlend">
-            <sequenceCmd name="Blend_1_1_Lin" type="lin" blend_radius="0.1"/>
+            <sequenceCmd name="Blend_1_1_Lin" type="lin" blend_radius="0.08"/>
             <sequenceCmd name="Blend_1_2_Lin" type="lin" blend_radius="0" />
         </sequence>
 
         <sequence name="InvalidLINLINBlend">
             <sequenceCmd name="Blend_1_1_Lin_invalid" type="lin" blend_radius="0.12"/>
-            <sequenceCmd name="Blend_1_2_Lin" type="lin" blend_radius="0.1" />
+            <sequenceCmd name="Blend_1_2_Lin" type="lin" blend_radius="0.08" />
             <sequenceCmd name="Blend_1_3_Lin" type="lin" blend_radius="0" />
         </sequence>
     </sequences>


### PR DESCRIPTION
## Description

These changes fix the test case `test_lin_lin_blend_execution` in [tst_api_execution_stop.py](https://github.com/PilzDE/pilz_industrial_motion/blob/noetic-devel/pilz_robot_programming/test/integrationtests/tst_api_execution_stop.py#L290).

The blend radius should be strictly less than the distance between start- end endpoint of the LIN commands. Before it was equal for one of the LIN commands.

### Things to add, update or check by the maintainers before this PR can be merged.

- [x] ~~Public api function documentation~~
- [x] ~~Architecture documentation reflects actual code structure~~
- [x] ~~[Tutorials](https://wiki.ros.org/pilz_robots/Tutorials/)~~
- [x] ~~Overview on [ROS wiki](https://wiki.ros.org/pilz_robots)~~
- [x] ~~Package Readme ([example pilz_robots](https://github.com/PilzDE/pilz_robots/blob/melodic-devel/README.md))~~
- [x] Good commit messages ([some tips](https://dev.to/jacobherrington/how-to-write-useful-commit-messages-my-commit-message-template-20n9))
- [x] ~~CHANGELOG.rst updated~~
- [x] ~~Copyright headers~~
- [x] ~~Examples~~

### Review Checklist
- [x] ~~Soft- and hardware architecture (diagrams and description)~~
- [x] Test review (test plan and individual test cases)
- [x] Documentation describes purpose of file(s) and responsibilities
- [x] Code (coding rules, style guide)

### Release planning (please answer)
- [x] When is the new feature released?
See #331
- [x] Which dependent packages do have to be released simultaneously?
See #331
