### PR TITLE
Remove wrong exec_depend from meta-package

### DIFF
--- a/pilz_industrial_motion/package.xml
+++ b/pilz_industrial_motion/package.xml
@@ -18,7 +18,6 @@
   <buildtool_depend>catkin</buildtool_depend>
 
   <exec_depend>pilz_msgs</exec_depend>
-  <exec_depend>pilz_industrial_motion_planner</exec_depend>
   <exec_depend>pilz_robot_programming</exec_depend>
 
   <export>


### PR DESCRIPTION
This created a wrong linking here: http://wiki.ros.org/pilz_industrial_motion