### PR TITLE
Fix visualization_msgs dependency

### DIFF
--- a/pilz_robot_programming/CMakeLists.txt
+++ b/pilz_robot_programming/CMakeLists.txt
@@ -30,6 +30,7 @@ catkin_install_python(PROGRAMS
 if(CATKIN_ENABLE_TESTING)
 
   find_package(rostest REQUIRED)
+  find_package(visualization_msgs REQUIRED)
 
   include_directories(
     ${catkin_INCLUDE_DIRS}

--- a/pilz_robot_programming/package.xml
+++ b/pilz_robot_programming/package.xml
@@ -37,6 +37,7 @@
   <test_depend>rostest</test_depend>
   <test_depend>rosunit</test_depend>
   <test_depend>code_coverage</test_depend>
+  <test_depend>visualization_msgs</test_depend>
 
 
 </package>

--- a/pilz_store_positions/CMakeLists.txt
+++ b/pilz_store_positions/CMakeLists.txt
@@ -5,7 +5,6 @@ find_package(catkin REQUIRED COMPONENTS
   roslint
   rospy
   std_msgs
-  visualization_msgs
 )
 
 if(CATKIN_ENABLE_TESTING AND ENABLE_COVERAGE_TESTING)

--- a/pilz_store_positions/package.xml
+++ b/pilz_store_positions/package.xml
@@ -27,7 +27,6 @@
   <test_depend>python-mock</test_depend>
   <test_depend>rostest</test_depend>
   <test_depend>ros_pytest</test_depend>
-  <test_depend>visualization_msgs</test_depend>
   <test_depend>code_coverage</test_depend>
   <test_depend>python-pytest-cov</test_depend>
 </package>


### PR DESCRIPTION
These changes fix the buildfarm error from here: https://build.ros.org/job/Mdev__pilz_industrial_motion__ubuntu_bionic_amd64/77/
