### PR TITLE
Fix finding pilz_industrial_motion_testutils

### DIFF
--- a/pilz_trajectory_generation/CMakeLists.txt
+++ b/pilz_trajectory_generation/CMakeLists.txt
@@ -212,6 +212,7 @@ if(CATKIN_ENABLE_TESTING)
 
   include_directories(
     ${pilz_testutils_INCLUDE_DIRS}
+    ${pilz_industrial_motion_testutils_INCLUDE_DIRS}
   )
 
   if(ENABLE_COVERAGE_TESTING)
@@ -240,6 +241,7 @@ if(CATKIN_ENABLE_TESTING)
   target_link_libraries(integrationtest_sequence_action_capability
     ${catkin_LIBRARIES}
     ${pilz_testutils_LIBRARIES}
+    ${pilz_industrial_motion_testutils_LIBRARIES}
     ${${PROJECT_NAME}_INTEGRATIONTEST_LIBRARIES}
   )
 
@@ -264,6 +266,7 @@ if(CATKIN_ENABLE_TESTING)
 
   target_link_libraries(integrationtest_sequence_service_capability
     ${catkin_LIBRARIES}
+    ${pilz_industrial_motion_testutils_LIBRARIES}
     ${${PROJECT_NAME}_INTEGRATIONTEST_LIBRARIES}
   )
 
@@ -288,6 +291,7 @@ if(CATKIN_ENABLE_TESTING)
 
   target_link_libraries(integrationtest_command_planning
     ${catkin_LIBRARIES}
+    ${pilz_industrial_motion_testutils_LIBRARIES}
     ${${PROJECT_NAME}_INTEGRATIONTEST_LIBRARIES}
   )
 
@@ -312,6 +316,7 @@ if(CATKIN_ENABLE_TESTING)
 
   target_link_libraries(integrationtest_command_list_manager
     ${catkin_LIBRARIES}
+    ${pilz_industrial_motion_testutils_LIBRARIES}
     ${${PROJECT_NAME}_INTEGRATIONTEST_LIBRARIES}
   )
 
@@ -402,6 +407,7 @@ if(CATKIN_ENABLE_TESTING)
 
   target_link_libraries(unittest_trajectory_blender_transition_window
     ${catkin_LIBRARIES}
+    ${pilz_industrial_motion_testutils_LIBRARIES}
     ${PROJECT_NAME}_testutils
   )
 
@@ -425,6 +431,7 @@ if(CATKIN_ENABLE_TESTING)
 
   target_link_libraries(unittest_trajectory_generator_circ
     ${catkin_LIBRARIES}
+    ${pilz_industrial_motion_testutils_LIBRARIES}
     ${PROJECT_NAME}_testutils
   )
 
@@ -436,6 +443,7 @@ if(CATKIN_ENABLE_TESTING)
 
   target_link_libraries(unittest_trajectory_generator_lin
     ${catkin_LIBRARIES}
+    ${pilz_industrial_motion_testutils_LIBRARIES}
     ${PROJECT_NAME}_testutils
   )
 

--- a/pilz_trajectory_generation/CMakeLists.txt
+++ b/pilz_trajectory_generation/CMakeLists.txt
@@ -22,7 +22,6 @@ find_package(catkin REQUIRED COMPONENTS
   eigen_conversions
   moveit_ros_move_group
   moveit_ros_planning_interface
-  pilz_industrial_motion_testutils
   kdl_conversions
 )
 
@@ -209,6 +208,7 @@ install(TARGETS
 if(CATKIN_ENABLE_TESTING)
   find_package(rostest REQUIRED)
   find_package(pilz_testutils REQUIRED)
+  find_package(pilz_industrial_motion_testutils REQUIRED)
 
   include_directories(
     ${pilz_testutils_INCLUDE_DIRS}


### PR DESCRIPTION
I just detected another annoying buildfarm error.

https://build.ros.org/job/Mdev__pilz_industrial_motion__ubuntu_bionic_amd64/79/console